### PR TITLE
Make the id concrete types

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -11,7 +11,7 @@ impl<T: Config> Pallet<T> {
 		if let Some(children) = Children::<T>::get(parent_collection_id, parent_nft_id) {
 			for child in children {
 				if child == (child_collection_id, child_nft_id) {
-					return true;
+					return true
 				} else {
 					if Pallet::<T>::is_x_descendent_of_y(
 						child_collection_id,

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -2,9 +2,9 @@ use super::*;
 
 impl<T: Config> Pallet<T> {
 	pub fn is_x_descendent_of_y(
-		child_collection_id: T::CollectionId,
+		child_collection_id: CollectionId,
 		child_nft_id: T::NftId,
-		parent_collection_id: T::CollectionId,
+		parent_collection_id: CollectionId,
 		parent_nft_id: T::NftId,
 	) -> bool {
 		let mut found_child = false;
@@ -28,7 +28,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn recursive_update_rootowner(
-		collection_id: T::CollectionId,
+		collection_id: CollectionId,
 		nft_id: T::NftId,
 		new_rootowner: T::AccountId,
 		max_recursions: u32,
@@ -54,7 +54,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn recursive_burn(
-		collection_id: T::CollectionId,
+		collection_id: CollectionId,
 		nft_id: T::NftId,
 		max_recursions: u32,
 	) -> DispatchResult {

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -3,9 +3,9 @@ use super::*;
 impl<T: Config> Pallet<T> {
 	pub fn is_x_descendent_of_y(
 		child_collection_id: CollectionId,
-		child_nft_id: T::NftId,
+		child_nft_id: NftId,
 		parent_collection_id: CollectionId,
-		parent_nft_id: T::NftId,
+		parent_nft_id: NftId,
 	) -> bool {
 		let mut found_child = false;
 		if let Some(children) = Children::<T>::get(parent_collection_id, parent_nft_id) {
@@ -29,7 +29,7 @@ impl<T: Config> Pallet<T> {
 
 	pub fn recursive_update_rootowner(
 		collection_id: CollectionId,
-		nft_id: T::NftId,
+		nft_id: NftId,
 		new_rootowner: T::AccountId,
 		max_recursions: u32,
 	) -> DispatchResult {
@@ -55,7 +55,7 @@ impl<T: Config> Pallet<T> {
 
 	pub fn recursive_burn(
 		collection_id: CollectionId,
-		nft_id: T::NftId,
+		nft_id: NftId,
 		max_recursions: u32,
 	) -> DispatchResult {
 		ensure!(max_recursions > 0, Error::<T>::TooManyRecursions);

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -20,7 +20,7 @@ use sp_std::{convert::TryInto, vec, vec::Vec};
 
 use types::{AccountIdOrCollectionNftTuple, ClassInfo, InstanceInfo, ResourceInfo};
 
-use rmrk_traits::{Collection, CollectionInfo};
+use rmrk_traits::{Collection, CollectionInfo, primitives::*};
 use sp_std::result::Result;
 
 mod functions;
@@ -37,11 +37,11 @@ mod tests;
 pub type InstanceInfoOf<T> = InstanceInfo<
 	<T as frame_system::Config>::AccountId,
 	BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
-	<T as pallet::Config>::CollectionId,
+	CollectionId,
 	<T as pallet::Config>::NftId,
 >;
 pub type ResourceOf<T> = ResourceInfo<
-	<T as pallet::Config>::ResourceId,
+	ResourceId,
 	BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
 >;
 
@@ -76,35 +76,23 @@ pub mod pallet {
 			+ From<Self::InstanceId>
 			+ Into<Self::InstanceId>;
 
-		type ResourceId: Member + Parameter + Default + Copy + HasCompact + AtLeast32BitUnsigned;
-
 		type MaxRecursions: Get<u32>;
-
-		/// The auction ID type.
-		type CollectionId: Parameter
-			+ Member
-			+ AtLeast32BitUnsigned
-			+ Default
-			+ Copy
-			+ MaybeSerializeDeserialize
-			+ Bounded
-			+ codec::FullCodec;
 	}
 
 	/// Next available NFT ID.
 	#[pallet::storage]
 	#[pallet::getter(fn next_nft_id)]
 	pub type NextNftId<T: Config> =
-		StorageMap<_, Twox64Concat, T::CollectionId, T::NftId, ValueQuery>;
+		StorageMap<_, Twox64Concat, CollectionId, T::NftId, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn collection_index)]
-	pub type CollectionIndex<T: Config> = StorageValue<_, T::CollectionId, ValueQuery>;
+	pub type CollectionIndex<T: Config> = StorageValue<_, CollectionId, ValueQuery>;
 
 	/// Next available Resource ID.
 	#[pallet::storage]
 	#[pallet::getter(fn next_resource_id)]
-	pub type NextResourceId<T: Config> = StorageValue<_, T::ResourceId, ValueQuery>;
+	pub type NextResourceId<T: Config> = StorageValue<_, ResourceId, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn collections)]
@@ -112,7 +100,7 @@ pub mod pallet {
 	pub type Collections<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
-		T::CollectionId,
+		CollectionId,
 		CollectionInfo<StringLimitOf<T>, T::AccountId>,
 	>;
 
@@ -120,7 +108,7 @@ pub mod pallet {
 	#[pallet::getter(fn get_nfts_by_owner)]
 	/// Stores collections info
 	pub type NftsByOwner<T: Config> =
-		StorageMap<_, Twox64Concat, T::AccountId, Vec<(T::CollectionId, T::NftId)>>;
+		StorageMap<_, Twox64Concat, T::AccountId, Vec<(CollectionId, T::NftId)>>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn nfts)]
@@ -128,7 +116,7 @@ pub mod pallet {
 	pub type NFTs<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
-		T::CollectionId,
+		CollectionId,
 		Twox64Concat,
 		T::NftId,
 		InstanceInfoOf<T>,
@@ -140,7 +128,7 @@ pub mod pallet {
 	pub type Priorities<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
-		T::CollectionId,
+		CollectionId,
 		Twox64Concat,
 		T::NftId,
 		Vec<BoundedVec<u8, T::StringLimit>>,
@@ -152,10 +140,10 @@ pub mod pallet {
 	pub type Children<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
-		T::CollectionId,
+		CollectionId,
 		Twox64Concat,
 		T::NftId,
-		Vec<(T::CollectionId, T::NftId)>,
+		Vec<(CollectionId, T::NftId)>,
 	>;
 
 	#[pallet::storage]
@@ -164,9 +152,9 @@ pub mod pallet {
 	pub type Resources<T: Config> = StorageNMap<
 		_,
 		(
-			NMapKey<Blake2_128Concat, T::CollectionId>,
+			NMapKey<Blake2_128Concat, CollectionId>,
 			NMapKey<Blake2_128Concat, T::NftId>,
-			NMapKey<Blake2_128Concat, T::ResourceId>,
+			NMapKey<Blake2_128Concat, ResourceId>,
 		),
 		ResourceOf<T>,
 		OptionQuery,
@@ -178,7 +166,7 @@ pub mod pallet {
 	pub(super) type Properties<T: Config> = StorageNMap<
 		_,
 		(
-			NMapKey<Blake2_128Concat, T::CollectionId>,
+			NMapKey<Blake2_128Concat, CollectionId>,
 			NMapKey<Blake2_128Concat, Option<T::NftId>>,
 			NMapKey<Blake2_128Concat, BoundedVec<u8, T::KeyLimit>>,
 		),
@@ -195,27 +183,27 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		CollectionCreated(T::AccountId, T::CollectionId),
-		NftMinted(T::AccountId, T::CollectionId, T::NftId),
+		CollectionCreated(T::AccountId, CollectionId),
+		NftMinted(T::AccountId, CollectionId, T::NftId),
 		NFTBurned(T::AccountId, T::NftId),
-		CollectionDestroyed(T::AccountId, T::CollectionId),
+		CollectionDestroyed(T::AccountId, CollectionId),
 		NFTSent(
 			T::AccountId,
-			AccountIdOrCollectionNftTuple<T::AccountId, T::CollectionId, T::NftId>,
-			T::CollectionId,
+			AccountIdOrCollectionNftTuple<T::AccountId, CollectionId, T::NftId>,
+			CollectionId,
 			T::NftId,
 		),
-		IssuerChanged(T::AccountId, T::AccountId, T::CollectionId),
+		IssuerChanged(T::AccountId, T::AccountId, CollectionId),
 		PropertySet(
-			T::CollectionId,
+			CollectionId,
 			Option<T::NftId>,
 			BoundedVec<u8, T::KeyLimit>,
 			BoundedVec<u8, T::ValueLimit>,
 		),
-		CollectionLocked(T::AccountId, T::CollectionId),
-		ResourceAdded(T::NftId, T::ResourceId),
-		ResourceAccepted(T::NftId, T::ResourceId),
-		PrioritySet(T::CollectionId, T::NftId),
+		CollectionLocked(T::AccountId, CollectionId),
+		ResourceAdded(T::NftId, ResourceId),
+		ResourceAccepted(T::NftId, ResourceId),
+		PrioritySet(CollectionId, T::NftId),
 	}
 
 	// Errors inform users that something went wrong.
@@ -259,7 +247,7 @@ pub mod pallet {
 		pub fn mint_nft(
 			origin: OriginFor<T>,
 			owner: T::AccountId,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 			recipient: T::AccountId,
 			royalty: Permill,
 			metadata: BoundedVec<u8, T::StringLimit>,
@@ -368,7 +356,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn burn_nft(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 			nft_id: T::NftId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
@@ -395,7 +383,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn destroy_collection(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 		) -> DispatchResult {
 			let sender = match T::ProtocolOrigin::try_origin(origin) {
 				Ok(_) => None,
@@ -419,9 +407,9 @@ pub mod pallet {
 		#[transactional]
 		pub fn send(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 			nft_id: T::NftId,
-			new_owner: AccountIdOrCollectionNftTuple<T::AccountId, T::CollectionId, T::NftId>,
+			new_owner: AccountIdOrCollectionNftTuple<T::AccountId, CollectionId, T::NftId>,
 		) -> DispatchResult {
 			let sender = match T::ProtocolOrigin::try_origin(origin) {
 				Ok(_) => None,
@@ -514,7 +502,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn change_issuer(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 			new_issuer: <T::Lookup as StaticLookup>::Source,
 		) -> DispatchResult {
 			let sender = match T::ProtocolOrigin::try_origin(origin) {
@@ -546,7 +534,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn set_property(
 			origin: OriginFor<T>,
-			#[pallet::compact] collection_id: T::CollectionId,
+			#[pallet::compact] collection_id: CollectionId,
 			maybe_nft_id: Option<T::NftId>,
 			key: BoundedVec<u8, T::KeyLimit>,
 			value: BoundedVec<u8, T::ValueLimit>,
@@ -579,7 +567,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn lock_collection(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 		) -> DispatchResult {
 			let sender = match T::ProtocolOrigin::try_origin(origin) {
 				Ok(_) => None,
@@ -600,7 +588,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn add_resource(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 			nft_id: T::NftId,
 			base: Option<BoundedVec<u8, T::StringLimit>>,
 			src: Option<BoundedVec<u8, T::StringLimit>>,
@@ -653,9 +641,9 @@ pub mod pallet {
 		#[transactional]
 		pub fn accept(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 			nft_id: T::NftId,
-			resource_id: T::ResourceId,
+			resource_id: ResourceId,
 		) -> DispatchResult {
 			let sender = match T::ProtocolOrigin::try_origin(origin) {
 				Ok(_) => None,
@@ -684,7 +672,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn set_priority(
 			origin: OriginFor<T>,
-			collection_id: T::CollectionId,
+			collection_id: CollectionId,
 			nft_id: T::NftId,
 			priorities: Vec<Vec<u8>>,
 		) -> DispatchResult {
@@ -721,17 +709,17 @@ pub mod pallet {
 			}
 		}
 
-		pub fn get_next_nft_id(collection_id: T::CollectionId) -> Result<T::NftId, Error<T>> {
+		pub fn get_next_nft_id(collection_id: CollectionId) -> Result<T::NftId, Error<T>> {
 			NextNftId::<T>::try_mutate(collection_id, |id| {
 				let current_id = *id;
 				*id = id.checked_add(&One::one()).ok_or(Error::<T>::NoAvailableNftId)?;
 				Ok(current_id)
 			})
 		}
-		pub fn get_next_resource_id() -> Result<T::ResourceId, Error<T>> {
+		pub fn get_next_resource_id() -> Result<ResourceId, Error<T>> {
 			NextResourceId::<T>::try_mutate(|id| {
 				let current_id = *id;
-				*id = id.checked_add(&One::one()).ok_or(Error::<T>::NoAvailableCollectionId)?;
+				*id = id.checked_add(1).ok_or(Error::<T>::NoAvailableCollectionId)?;
 				Ok(current_id)
 			})
 		}
@@ -739,9 +727,7 @@ pub mod pallet {
 }
 
 impl<T: Config> Collection<StringLimitOf<T>, T::AccountId> for Pallet<T> {
-	type CollectionId = T::CollectionId;
-
-	fn issuer(collection_id: Self::CollectionId) -> Option<T::AccountId> {
+	fn issuer(collection_id: CollectionId) -> Option<T::AccountId> {
 		None
 	}
 	fn create_collection(
@@ -749,13 +735,13 @@ impl<T: Config> Collection<StringLimitOf<T>, T::AccountId> for Pallet<T> {
 		metadata: StringLimitOf<T>,
 		max: u32,
 		symbol: StringLimitOf<T>,
-	) -> Result<Self::CollectionId, DispatchError> {
+	) -> Result<CollectionId, DispatchError> {
 		let collection = CollectionInfo { issuer: issuer.clone(), metadata, max, symbol };
 		let collection_id = <CollectionIndex<T>>::try_mutate(
-			|n| -> Result<Self::CollectionId, DispatchError> {
+			|n| -> Result<CollectionId, DispatchError> {
 				let id = *n;
-				ensure!(id != Self::CollectionId::max_value(), Error::<T>::NoAvailableCollectionId);
-				*n += One::one();
+				ensure!(id != CollectionId::max_value(), Error::<T>::NoAvailableCollectionId);
+				*n += 1;
 				Ok(id)
 			},
 		)?;
@@ -763,7 +749,7 @@ impl<T: Config> Collection<StringLimitOf<T>, T::AccountId> for Pallet<T> {
 		Ok(collection_id)
 	}
 
-	fn burn_collection(issuer: T::AccountId, collection_id: T::CollectionId) -> DispatchResult {
+	fn burn_collection(issuer: T::AccountId, collection_id: CollectionId) -> DispatchResult {
 		ensure!(
 			NFTs::<T>::iter_prefix_values(collection_id).count() == 0,
 			Error::<T>::CollectionNotEmpty
@@ -773,9 +759,9 @@ impl<T: Config> Collection<StringLimitOf<T>, T::AccountId> for Pallet<T> {
 	}
 
 	fn change_issuer(
-		collection_id: T::CollectionId,
+		collection_id: CollectionId,
 		new_issuer: T::AccountId,
-	) -> Result<(T::AccountId, Self::CollectionId), DispatchError> {
+	) -> Result<(T::AccountId, CollectionId), DispatchError> {
 		ensure!(Collections::<T>::contains_key(collection_id), Error::<T>::NoAvailableCollectionId);
 
 		Collections::<T>::try_mutate_exists(collection_id, |collection| -> DispatchResult {
@@ -789,8 +775,8 @@ impl<T: Config> Collection<StringLimitOf<T>, T::AccountId> for Pallet<T> {
 	}
 
 	fn lock_collection(
-		collection_id: T::CollectionId,
-	) -> Result<Self::CollectionId, DispatchError> {
+		collection_id: CollectionId,
+	) -> Result<CollectionId, DispatchError> {
 		Collections::<T>::try_mutate_exists(collection_id, |collection| -> DispatchResult {
 			let collection = collection.as_mut().ok_or(Error::<T>::CollectionUnknown)?;
 			let currently_minted = NFTs::<T>::iter_prefix_values(collection_id).count();

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -213,7 +213,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T>
 	where
-		T: pallet_uniques::Config<ClassId = u32, InstanceId = u32>,
+		T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
 	{
 		/// Mints an NFT in the specified collection
 		/// Sets metadata and the royalty attribute

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -43,7 +43,6 @@ parameter_types! {
 impl pallet_rmrk_core::Config for Test {
 	// type Currency = Balances;
 	type Event = Event;
-	type NftId = u32;
 	type ProtocolOrigin = EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
 }

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -43,9 +43,7 @@ parameter_types! {
 impl pallet_rmrk_core::Config for Test {
 	// type Currency = Balances;
 	type Event = Event;
-	type CollectionId = u32;
 	type NftId = u32;
-	type ResourceId = u32;
 	type ProtocolOrigin = EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -49,7 +49,7 @@ fn create_collection_works() {
 		// 	Error::<Test>::TooLong
 		// );
 		// NextCollectionId::<Test>::mutate(|id| *id = <Test as UNQ::Config>::ClassId::max_value());
-		CollectionIndex::<Test>::mutate(|id| *id = <Test as Config>::CollectionId::max_value());
+		CollectionIndex::<Test>::mutate(|id| *id = CollectionId::max_value());
 		assert_noop!(
 			RMRKCore::create_collection(
 				Origin::signed(ALICE),

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -320,7 +320,8 @@ fn send_nft_removes_existing_parent() {
 
 // #[test]
 // TODO fn cannot send to its own descendent?  this should be easy enough to check
-// TODO fn cannot send to its own grandparent?  this seems difficult to check without implementing a new Parent storage struct
+// TODO fn cannot send to its own grandparent?  this seems difficult to check without implementing a
+// new Parent storage struct
 
 #[test]
 fn change_issuer_works() {

--- a/pallets/rmrk-core/src/types.rs
+++ b/pallets/rmrk-core/src/types.rs
@@ -42,30 +42,34 @@ pub struct InstanceInfo<AccountId, BoundedString, CollectionId, NftId> {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct ResourceInfo<ResourceId, BoundedString> {
 	/// id is a 5-character string of reasonable uniqueness.
-	/// The combination of base ID and resource id should be unique across the entire RMRK ecosystem which
+	/// The combination of base ID and resource id should be unique across the entire RMRK
+	/// ecosystem which
 	pub id: ResourceId,
 
 	/// If resource is sent to non-rootowned NFT, pending will be false and need to be accepted
 	pub pending: bool,
 
-	/// A Base is uniquely identified by the combination of the word `base`, its minting block number,
-	/// and user provided symbol during Base creation, glued by dashes `-`, e.g. base-4477293-kanaria_superbird.
+	/// A Base is uniquely identified by the combination of the word `base`, its minting block
+	/// number, and user provided symbol during Base creation, glued by dashes `-`, e.g.
+	/// base-4477293-kanaria_superbird.
 	pub base: Option<BoundedString>,
-	/// If the resource is Media, the base property is absent. Media src should be a URI like an IPFS hash.
+	/// If the resource is Media, the base property is absent. Media src should be a URI like an
+	/// IPFS hash.
 	pub src: Option<BoundedString>,
 	pub metadata: Option<BoundedString>,
 	/// If the resource has the slot property, it was designed to fit into a specific Base's slot.
-	/// The baseslot will be composed of two dot-delimited values, like so: "base-4477293-kanaria_superbird.machine_gun_scope".
-	/// This means: "This resource is compatible with the machine_gun_scope slot of base base-4477293-kanaria_superbird
+	/// The baseslot will be composed of two dot-delimited values, like so:
+	/// "base-4477293-kanaria_superbird.machine_gun_scope". This means: "This resource is
+	/// compatible with the machine_gun_scope slot of base base-4477293-kanaria_superbird
 	pub slot: Option<BoundedString>,
-	/// The license field, if present, should contain a link to a license (IPFS or static HTTP url), or an identifier,
-	/// like RMRK_nocopy or ipfs://ipfs/someHashOfLicense.
+	/// The license field, if present, should contain a link to a license (IPFS or static HTTP
+	/// url), or an identifier, like RMRK_nocopy or ipfs://ipfs/someHashOfLicense.
 	pub license: Option<BoundedString>,
-	/// If the resource has the thumb property, this will be a URI to a thumbnail of the given resource. For example,
-	/// if we have a composable NFT like a Kanaria bird, the resource is complex and too detailed to show in a
-	/// search-results page or a list. Also, if a bird owns another bird,
-	/// showing the full render of one bird inside the other's inventory might be a bit of a
-	/// strain on the browser. For this reason, the thumb value can contain a URI to an image that is
-	/// lighter and faster to load but representative of this resource.
+	/// If the resource has the thumb property, this will be a URI to a thumbnail of the given
+	/// resource. For example, if we have a composable NFT like a Kanaria bird, the resource is
+	/// complex and too detailed to show in a search-results page or a list. Also, if a bird owns
+	/// another bird, showing the full render of one bird inside the other's inventory might be a
+	/// bit of a strain on the browser. For this reason, the thumb value can contain a URI to an
+	/// image that is lighter and faster to load but representative of this resource.
 	pub thumb: Option<BoundedString>,
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -295,9 +295,7 @@ parameter_types! {
 impl pallet_rmrk_core::Config for Runtime {
 	// type Currency = Balances;
 	type Event = Event;
-	type CollectionId = u32;
 	type NftId = u32;
-	type ResourceId = u32;
 	type ProtocolOrigin = frame_system::EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -293,9 +293,7 @@ parameter_types! {
 }
 
 impl pallet_rmrk_core::Config for Runtime {
-	// type Currency = Balances;
 	type Event = Event;
-	type NftId = u32;
 	type ProtocolOrigin = frame_system::EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
 }

--- a/traits/src/collection.rs
+++ b/traits/src/collection.rs
@@ -3,6 +3,8 @@ use scale_info::TypeInfo;
 use sp_runtime::{DispatchError, DispatchResult, RuntimeDebug};
 use sp_std::{cmp::Eq, result};
 
+use crate::primitives::*;
+
 /// Collection info.
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
 #[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
@@ -17,25 +19,24 @@ pub struct CollectionInfo<BoundedString, AccountId> {
 /// Abstraction over a Collection system.
 #[allow(clippy::upper_case_acronyms)]
 pub trait Collection<BoundedString, AccountId> {
-	type CollectionId: Default + Copy;
 	// fn collection_two_info(
 	// 	id: Self::CollectionTwoId,
 	// ) -> Option<CollectionTwoInfo<AccountId, BoundedString>>;
-	fn issuer(collection_id: Self::CollectionId) -> Option<AccountId>;
+	fn issuer(collection_id: CollectionId) -> Option<AccountId>;
 	fn create_collection(
 		issuer: AccountId,
 		metadata: BoundedString,
 		max: u32,
 		symbol: BoundedString,
-	) -> sp_std::result::Result<Self::CollectionId, DispatchError>;
-	fn burn_collection(issuer: AccountId, collection_id: Self::CollectionId) -> DispatchResult;
+	) -> sp_std::result::Result<CollectionId, DispatchError>;
+	fn burn_collection(issuer: AccountId, collection_id: CollectionId) -> DispatchResult;
 	fn change_issuer(
-		collection_id: Self::CollectionId,
+		collection_id: CollectionId,
 		new_issuer: AccountId,
-	) -> sp_std::result::Result<(AccountId, Self::CollectionId), DispatchError>;
+	) -> sp_std::result::Result<(AccountId, CollectionId), DispatchError>;
 	fn lock_collection(
-		collection_id: Self::CollectionId,
-	) -> sp_std::result::Result<Self::CollectionId, DispatchError>;
+		collection_id: CollectionId,
+	) -> sp_std::result::Result<CollectionId, DispatchError>;
 }
 
 // #[derive(Encode, Decode, Eq, Copy, PartialEq, Clone, RuntimeDebug, TypeInfo)]

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -4,6 +4,11 @@ pub mod collection;
 
 pub use collection::{Collection, CollectionInfo};
 
+pub mod primitives {
+	pub type CollectionId = u32;
+	pub type ResourceId = u32;
+}
+
 // use codec::{Decode, Encode};
 // use impl_trait_for_tuples::impl_for_tuples;
 // use sp_runtime::{DispatchResult, RuntimeDebug};

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -7,6 +7,7 @@ pub use collection::{Collection, CollectionInfo};
 pub mod primitives {
 	pub type CollectionId = u32;
 	pub type ResourceId = u32;
+	pub type NftId = u32;
 }
 
 // use codec::{Decode, Encode};


### PR DESCRIPTION
This PR addresses the concerns mentioned in #24. It minimizes the generic type used in the pallets while keep the upstream `pallet-unique` integration.

Tested: cargo test