### PR TITLE
Lazy ownership tree based on pallet-unique's owner

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -108,19 +108,18 @@ where
 	) -> sp_std::result::Result<(CollectionId, NftId), DispatchError> {
 		ensure!(max_recursions > 0, Error::<T>::TooManyRecursions);
 		NFTs::<T>::remove(collection_id, nft_id);
-		if let kids = Children::<T>::take((collection_id, nft_id)) {
-			for (child_collection_id, child_nft_id) in kids {
-				// Remove child from Children StorageMap
-				Pallet::<T>::remove_child(
-					(collection_id, nft_id),
-					(child_collection_id, child_nft_id)
-				);
-				Self::nft_burn(
-					child_collection_id,
-					child_nft_id,
-					max_recursions - 1,
-				)?;
-			}
+		let kids = Children::<T>::take((collection_id, nft_id));
+		for (child_collection_id, child_nft_id) in kids {
+			// Remove child from Children StorageMap
+			Pallet::<T>::remove_child(
+				(collection_id, nft_id),
+				(child_collection_id, child_nft_id)
+			);
+			Self::nft_burn(
+				child_collection_id,
+				child_nft_id,
+				max_recursions - 1,
+			)?;
 		}
 		Ok((collection_id, nft_id))
 	}
@@ -355,10 +354,9 @@ where
 	) -> DispatchResult {
 		ensure!(max_recursions > 0, Error::<T>::TooManyRecursions);
 		NFTs::<T>::remove(collection_id, nft_id);
-		if let kids = Children::<T>::take((collection_id, nft_id)) {
-			for (child_collection_id, child_nft_id) in kids {
-				Pallet::<T>::recursive_burn(child_collection_id, child_nft_id, max_recursions - 1)?;
-			}
+		let kids = Children::<T>::take((collection_id, nft_id));
+		for (child_collection_id, child_nft_id) in kids {
+			Pallet::<T>::recursive_burn(child_collection_id, child_nft_id, max_recursions - 1)?;
 		}
 		Ok(())
 	}

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -312,14 +312,6 @@ where
 	///
 	/// Output:
 	/// `AccountId`: Encoded virtual account that represents the NFT
-	///
-	/// # Example
-	/// ```
-	/// let collection_id = 0;
-	/// let nft_id = 0;
-	///
-	/// assert_eq!(nft_to_account_id(collection_id, nft_id), "5Co5sje8foechzYWmKU7PgQsBX349YhqaMb8kZHu19HyYNEQ");
-	/// ```
 	pub fn nft_to_account_id<AccountId: Codec>(collection_id: CollectionId, nft_id: NftId) -> AccountId {
 		(SALT_RMRK_NFT, collection_id, nft_id)
 			.using_encoded(|b| AccountId::decode(&mut TrailingZeroInput::new(b)))
@@ -336,14 +328,6 @@ where
 	///
 	/// Output:
 	/// `Option<(CollectionId, NftId)>`
-	/// # Example
-	/// ```
-	/// let virtual_account = "5Co5sje8foechzYWmKU7PgQsBX349YhqaMb8kZHu19HyYNEQ";
-	/// let collection_id = 0;
-	/// let nft_id = 0;
-	///
-	/// assert_eq!(decode_nft_account_id(virtual_account), Some((collection_id, nft_id)));
-	/// ```
 	pub fn decode_nft_account_id<AccountId: Codec>(account_id: T::AccountId) -> Option<(CollectionId, NftId)> {
 		let (prefix, tuple, suffix) = account_id
 			.using_encoded(|mut b| {
@@ -370,19 +354,6 @@ where
 	///
 	/// Output:
 	/// - `Result<(T::AcccountId, (CollectionId, NftId)), Error<T>>`
-	///
-	/// # Example
-	/// ```
-	/// let parent = Origin::signed(ALICE);
-	/// // Alice mints NFTs (0,0) and (0,1) then send (0,1) to (0,0)
-	/// let virtual_account = "5Co5sje8foechzYWmKU7PgQsBX349YhqaMb8kZHu19HyYNEQ";
-	/// let collection_id = 0;
-	/// let nft_id = 1;
-	/// let cid = 0;
-	/// let nid = 0;
-	///
-	/// assert_eq!(lookup_root_owner(collection_id, nft_id), Ok((parent, (collection_id, nft_id))));
-	/// ```
 	pub fn lookup_root_owner(collection_id: CollectionId, nft_id: NftId) -> Result<(T::AccountId, (CollectionId, NftId)), Error<T>> {
 		let parent =
 			pallet_uniques::Pallet::<T>::owner(collection_id, nft_id);

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -1,6 +1,23 @@
+use codec::Encode;
+use sp_core::blake2_256;
 use super::*;
 
 impl<T: Config> Pallet<T> {
+
+	pub fn nft_to_account_id(collection_id: CollectionId, nft_id: NftId) -> AccountId {
+		let preimage = (b"RmrkNft", collleciton_id, nft_id).encode();
+		let hash = blake2_256(&preimage);
+		AccountId::from(&hash)
+	}
+
+	fn lookup_root(collection_id: CollectionId, nft_id: NftId) -> (T::AccountId, (CollectionId,NftId)) {
+		let parent = pallet_unique::Pallet::<T>::owner_of(collection_id, nft_id);
+		match AccountPreimage::<T>::get(parent) {
+			None => (parent, (collection_id, nft_id)),
+			Some((collection_id, nft_id)) => lookup_root_owner(collection_id, nft_id),
+		}
+	}
+
 	pub fn is_x_descendent_of_y(
 		child_collection_id: CollectionId,
 		child_nft_id: NftId,

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -290,6 +290,7 @@ where
 			},
 		};
 
+		sending_nft.owner = new_owner.clone();
 		NFTs::<T>::insert(collection_id, nft_id, sending_nft);
 
 		Ok(new_owner_account)

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -61,7 +61,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + pallet_uniques::Config {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
-
 		type ProtocolOrigin: EnsureOrigin<Self::Origin>;
 		type MaxRecursions: Get<u32>;
 	}
@@ -126,8 +125,8 @@ pub mod pallet {
 	/// Stores reverse map of nft's root account owner
 	pub type AccountPreimage<T: Config> = StorageMap<
 		_,
-		T::AccountId,
 		Twox64Concat,
+		T::AccountId,
 		(CollectionId, NftId),
 	>;
 
@@ -348,9 +347,9 @@ pub mod pallet {
 			nft_id: NftId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
-			let (root_owner, _) = Pallet::<T>::lookup_root(collection_id, nft_id);
+			let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
 			// Check ownership
-			ensure!(sender == root_owner, Error::BadOrigin);
+			ensure!(sender == root_owner, Error::<T>::NoPermission);
 			let max_recursions = T::MaxRecursions::get();
 			let (_collection_id, nft_id) = Self::nft_burn(collection_id, nft_id, max_recursions)?;
 

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -122,6 +122,16 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
+	#[pallet::getter(fn account_preimage)]
+	/// Stores reverse map of nft's root account owner
+	pub type AccountPreimage<T: Config> = StorageMap<
+		_,
+		T::AccountId,
+		Twox64Concat,
+		(CollectionId, NftId),
+	>;
+
+	#[pallet::storage]
 	#[pallet::getter(fn resources)]
 	/// Stores resource info
 	pub type Resources<T: Config> = StorageNMap<
@@ -338,6 +348,9 @@ pub mod pallet {
 			nft_id: NftId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
+			let (root_owner, _) = Pallet::<T>::lookup_root(collection_id, nft_id);
+			// Check ownership
+			ensure!(sender == root_owner, Error::BadOrigin);
 			let max_recursions = T::MaxRecursions::get();
 			let (_collection_id, nft_id) = Self::nft_burn(collection_id, nft_id, max_recursions)?;
 

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -15,7 +15,7 @@ mod nfc {
 	pub use super::super::*;
 }
 
-type AccountId = AccountId32;
+pub(crate) type AccountId = AccountId32;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type Balance = u128;

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -15,7 +15,7 @@ mod nfc {
 	pub use super::super::*;
 }
 
-pub(crate) type AccountId = AccountId32;
+type AccountId = AccountId32;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type Balance = u128;

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -398,8 +398,9 @@ fn burn_nft_works() {
 			Some(Permill::from_float(0.0)),
 			bvec![0u8; 20]
 		));
+		assert_noop!(RMRKCore::burn_nft(Origin::signed(BOB), COLLECTION_ID_0, NFT_ID_0), Error::<Test>::NoPermission);
 		assert_ok!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, NFT_ID_0));
-		assert_noop!(RMRKCore::burn_nft(Origin::signed(BOB), COLLECTION_ID_0, NFT_ID_0), Error::<Test>::BadOrigin);
+		assert_noop!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, NFT_ID_0), Error::<Test>::NoAvailableNftId);
 		assert_eq!(RMRKCore::nfts(COLLECTION_ID_0, NFT_ID_0).is_none(), true);
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NFTBurned {
 			owner: ALICE,

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -196,6 +196,17 @@ fn send_nft_to_minted_nft_works() {
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		);
 
+		// Error if trying to assign send a nft to self nft
+		assert_noop!(
+			RMRKCore::send(
+				Origin::signed(BOB),
+				0,
+				0,
+				AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0)
+			),
+			Error::<Test>::CircleDetected
+		);
+
 		// Check that Bob now root-owns NFT (0, 1) [child] since he wasn't originally rootowner
 		assert_eq!(RMRKCore::nfts(0, 1).unwrap().rootowner, BOB);
 

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -399,6 +399,7 @@ fn burn_nft_works() {
 			bvec![0u8; 20]
 		));
 		assert_ok!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, NFT_ID_0));
+		assert_noop!(RMRKCore::burn_nft(Origin::signed(BOB), COLLECTION_ID_0, NFT_ID_0), Error::<Test>::BadOrigin);
 		assert_eq!(RMRKCore::nfts(COLLECTION_ID_0, NFT_ID_0).is_none(), true);
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NFTBurned {
 			owner: ALICE,

--- a/pallets/rmrk-core/src/types.rs
+++ b/pallets/rmrk-core/src/types.rs
@@ -19,8 +19,6 @@ pub struct ClassInfo<BoundedString, AccountId> {
 
 #[derive(Encode, Decode, Eq, Copy, PartialEq, Clone, RuntimeDebug, TypeInfo)]
 pub struct InstanceInfo<AccountId, BoundedString> {
-	/// The rootowner of the account, must be an account
-	pub rootowner: AccountId,
 	/// The owner of the NFT, can be either an Account or a tuple (CollectionId, NftId)
 	pub owner: AccountIdOrCollectionNftTuple<AccountId>,
 	/// The user account which receives the royalty

--- a/pallets/rmrk-core/src/types.rs
+++ b/pallets/rmrk-core/src/types.rs
@@ -19,8 +19,6 @@ pub struct ClassInfo<BoundedString, AccountId> {
 
 #[derive(Encode, Decode, Eq, Copy, PartialEq, Clone, RuntimeDebug, TypeInfo)]
 pub struct InstanceInfo<AccountId, BoundedString> {
-	/// The owner of the NFT, can be either an Account or a tuple (CollectionId, NftId)
-	pub owner: AccountIdOrCollectionNftTuple<AccountId>,
 	/// The user account which receives the royalty
 	pub recipient: AccountId,
 	/// Royalty in per mille (1/1000)

--- a/pallets/uniques/src/functions.rs
+++ b/pallets/uniques/src/functions.rs
@@ -22,7 +22,7 @@ use frame_support::{ensure, traits::Get};
 use sp_runtime::{DispatchError, DispatchResult};
 
 impl<T: Config<I>, I: 'static> Pallet<T, I> {
-	pub(crate) fn do_transfer(
+	pub fn do_transfer(
 		class: T::ClassId,
 		instance: T::InstanceId,
 		dest: T::AccountId,

--- a/traits/src/nft.rs
+++ b/traits/src/nft.rs
@@ -23,8 +23,6 @@ pub enum AccountIdOrCollectionNftTuple<AccountId> {
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
 #[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
 pub struct NftInfo<AccountId, BoundedString> {
-	/// The rootowner of the account, must be an account
-	pub rootowner: AccountId,
 	/// The owner of the NFT, can be either an Account or a tuple (CollectionId, NftId)
 	pub owner: AccountIdOrCollectionNftTuple<AccountId>,
 	/// The user account which receives the royalty
@@ -59,5 +57,5 @@ pub trait Nft<AccountId, BoundedString> {
 		nft_id: NftId,
 		new_owner: AccountIdOrCollectionNftTuple<AccountId>,
 		max_recursions: u32,
-	) -> Result<(CollectionId, NftId), DispatchError>;
+	) -> Result<AccountId, DispatchError>;
 }


### PR DESCRIPTION
## Targets
* [x]  Update mint to use uniques pallet's mint
* [x]  Ownership check
* [x]  Create virtual account for NFT
* [x]  Update transfer to check ownership & create virtual account if transferred to an NFT (Do we need to handle pending logic, yet?)
* [x] Update logic to `send_nft` to utilize lazy ownership tree
* [x] Handle children logic after `do_transfer`
* [x]  Rebase and fix conflicts

## Procedure
* User mints an NFT with `pallet_unique::Pallet::<T>::mint(origin, owner, col, nft)?;`
* User `transfer(origin: OriginFor<T>, col: CollectionId, nft: NftId, dest: AccountIdOrNftTuple)` NFT to another NFT
* Check ownership with `lookup_root_owner(col, nft)`
  * `match` `dest_account` to `AccountId(id)` if Account owner
  * else if match on `NFTTuple(c,n)` then call `lookup_root_owner(c, n)` & if no circle detection triggered then convert to virtual account with `nft_to_account_id(c, n)`
* check children 
  * If `origin` does transfer then auto-accept NFT & set `pending` === false
  * else set NFT property `pending` === true
* Emit Event `NFTSent`

## RMRK Specs
* [SEND](https://github.com/rmrk-team/rmrk-spec/blob/master/standards/rmrk2.0.0/interactions/send.md)
* [ACCEPT](https://github.com/rmrk-team/rmrk-spec/blob/master/standards/rmrk2.0.0/interactions/accept.md)