### PR TITLE
Prevent minting when next NFT id is greater than the collection max.

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -70,14 +70,12 @@ impl<T: Config> Nft<T::AccountId, StringLimitOf<T>> for Pallet<T> {
 		metadata: StringLimitOf<T>,
 	) -> sp_std::result::Result<(CollectionId, NftId), DispatchError> {
 		let nft_id = Self::get_next_nft_id(collection_id)?;
-
 		let collection = Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
-
-		let nfts_minted = NFTs::<T>::iter_prefix_values(collection_id).count();
 		let max: u32 = collection.max.try_into().unwrap();
 
+		// Prevent minting when next NFT id is greater than the collection max.
 		ensure!(
-			nfts_minted < max.try_into().unwrap() || max == 0,
+			nft_id < max.try_into().unwrap() || max == max - max,
 			Error::<T>::CollectionFullOrLocked
 		);
 

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -242,16 +242,16 @@ pub mod pallet {
 			let collection =
 				Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
 
+			let nft_id: NftId = Self::get_next_nft_id(collection_id)?;
+
 			let nfts_minted = NFTs::<T>::iter_prefix_values(collection_id).count();
 			let max: u32 = collection.max.try_into().unwrap();
 
 			ensure!(
 				// Probably a better way to do "max == 0"
-				nfts_minted < max.try_into().unwrap() || max == max - max,
+				nft_id < max.try_into().unwrap() || max == max - max,
 				Error::<T>::CollectionFullOrLocked
 			);
-
-			let nft_id: NftId = Self::get_next_nft_id(collection_id)?;
 
 			// let metadata_bounded = Self::to_bounded_string(metadata)?;
 			// if let Some(r) = royalty {

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -243,8 +243,6 @@ pub mod pallet {
 				Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
 
 			let nft_id: NftId = Self::get_next_nft_id(collection_id)?;
-
-			let nfts_minted = NFTs::<T>::iter_prefix_values(collection_id).count();
 			let max: u32 = collection.max.try_into().unwrap();
 
 			ensure!(

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -69,7 +69,7 @@ fn mint_nft_works() {
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
 			ALICE,
-			0,
+			COLLECTION_ID_0,
 			ALICE,
 			Permill::from_float(20.525),
 			bvec![0u8; 20]
@@ -103,6 +103,34 @@ fn mint_nft_works() {
 		);
 	});
 }
+
+#[test]
+fn mint_collection_max_logic_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(RMRKCore::create_collection(Origin::signed(ALICE), bvec![0u8; 20], Some(1), bvec![0u8; 15]));
+		assert_ok!(RMRKCore::mint_nft(
+			Origin::signed(ALICE),
+			ALICE,
+			COLLECTION_ID_0,
+			ALICE,
+			Permill::from_float(20.525),
+			bvec![0u8; 20]
+		));
+		assert_ok!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, 0));
+		assert_noop!(
+			RMRKCore::mint_nft(
+				Origin::signed(ALICE),
+				ALICE,
+				COLLECTION_ID_0,
+				CHARLIE,
+				Permill::from_float(20.525),
+				bvec![0u8; 20]
+			),
+			Error::<Test>::CollectionFullOrLocked
+		);
+	});
+}
+
 #[test]
 fn send_nft_to_minted_nft_works() {
 	ExtBuilder::default().build().execute_with(|| {


### PR DESCRIPTION
Poking around to learn and to hopefully contribute.

**Work done**
* Get next available NFT and ensure it is less than collection max
* Tests included.

It does seem to follow the specified domain logic to my understanding.
The following steps ends in a `CollectionFullOrLocked` error:
 - Create collection with max = 2
 - Mint 2 items into collection
 - Burn one of the items
 - Try to mint a third.
 -  => `CollectionFullOrLocked`
 
 **Questions:**
 * Is this the desired logic?
 * Should it have a distinct error enum type?
 
**Possible fix to #10** 