### PR TITLE
Simplify ensure signed checks 

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -103,11 +103,7 @@ impl<T: Config> Nft<T::AccountId, StringLimitOf<T>> for Pallet<T> {
 		NFTs::<T>::remove(collection_id, nft_id);
 		if let Some(kids) = Children::<T>::take(collection_id, nft_id) {
 			for (child_collection_id, child_nft_id) in kids {
-				Self::nft_burn(
-					child_collection_id,
-					child_nft_id,
-					max_recursions - 1,
-				)?;
+				Self::nft_burn(child_collection_id, child_nft_id, max_recursions - 1)?;
 			}
 		}
 		Ok((collection_id, nft_id))
@@ -262,7 +258,7 @@ impl<T: Config> Pallet<T> {
 		Ok(match name {
 			Some(n) => Some(Self::to_bounded_string(n)?),
 			None => None,
-		})		
+		})
 	}
 
 	pub fn get_next_nft_id(collection_id: CollectionId) -> Result<NftId, Error<T>> {

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -4,8 +4,7 @@ use sp_runtime::Permill;
 // use crate::types::ClassType;
 
 use super::*;
-use mock::Event as MockEvent;
-use mock::*;
+use mock::{Event as MockEvent, *};
 use pallet_uniques as UNQ;
 use sp_std::{convert::TryInto, vec::Vec};
 
@@ -117,7 +116,12 @@ fn mint_nft_works() {
 #[test]
 fn mint_collection_max_logic_works() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(RMRKCore::create_collection(Origin::signed(ALICE), bvec![0u8; 20], Some(1), bvec![0u8; 15]));
+		assert_ok!(RMRKCore::create_collection(
+			Origin::signed(ALICE),
+			bvec![0u8; 20],
+			Some(1),
+			bvec![0u8; 15]
+		));
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
 			ALICE,


### PR DESCRIPTION
Simplify and ensure all calls are signed. Addressing #36
When / if needed we can add extra checks back (such as `ensure_protocol_or_signed`)