### PR TITLE
Avoid iteration when checking collection size

### DIFF
--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -252,14 +252,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
 
-			let (collection_id, nft_id) = Self::nft_mint(
-				sender.clone(),
-				owner,
-				collection_id,
-				recipient,
-				royalty,
-				metadata,
-			)?;
+			let (collection_id, nft_id) =
+				Self::nft_mint(sender.clone(), owner, collection_id, recipient, royalty, metadata)?;
 
 			pallet_uniques::Pallet::<T>::do_mint(
 				collection_id,
@@ -268,11 +262,7 @@ pub mod pallet {
 				|_details| Ok(()),
 			)?;
 
-			Self::deposit_event(Event::NftMinted {
-				owner: sender,
-				collection_id,
-				nft_id,
-			});
+			Self::deposit_event(Event::NftMinted { owner: sender, collection_id, nft_id });
 
 			Ok(())
 		}
@@ -290,8 +280,7 @@ pub mod pallet {
 
 			let max = max.unwrap_or_default();
 
-			let collection_id =
-				Self::collection_create(sender.clone(), metadata, max, symbol)?;
+			let collection_id = Self::collection_create(sender.clone(), metadata, max, symbol)?;
 
 			pallet_uniques::Pallet::<T>::do_create_class(
 				collection_id,
@@ -299,17 +288,10 @@ pub mod pallet {
 				sender.clone(),
 				T::ClassDeposit::get(),
 				false,
-				pallet_uniques::Event::Created(
-					collection_id,
-					sender.clone(),
-					sender.clone(),
-				),
+				pallet_uniques::Event::Created(collection_id, sender.clone(), sender.clone()),
 			)?;
 
-			Self::deposit_event(Event::CollectionCreated {
-				issuer: sender.clone(),
-				collection_id,
-			});
+			Self::deposit_event(Event::CollectionCreated { issuer: sender.clone(), collection_id });
 			Ok(())
 		}
 
@@ -346,12 +328,13 @@ pub mod pallet {
 				.ok_or(Error::<T>::NoWitness)?;
 			ensure!(witness.instances == 0u32, Error::<T>::CollectionNotEmpty);
 
-			pallet_uniques::Pallet::<T>::do_destroy_class(collection_id, witness, sender.clone().into())?;
-
-			Self::deposit_event(Event::CollectionDestroyed {
-				issuer: sender,
+			pallet_uniques::Pallet::<T>::do_destroy_class(
 				collection_id,
-			});
+				witness,
+				sender.clone().into(),
+			)?;
+
+			Self::deposit_event(Event::CollectionDestroyed { issuer: sender, collection_id });
 			Ok(())
 		}
 
@@ -452,10 +435,7 @@ pub mod pallet {
 
 			let collection_id = Self::collection_lock(collection_id)?;
 
-			Self::deposit_event(Event::CollectionLocked {
-				issuer: sender,
-				collection_id,
-			});
+			Self::deposit_event(Event::CollectionLocked { issuer: sender, collection_id });
 			Ok(())
 		}
 

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -83,6 +83,7 @@ fn mint_nft_works() {
 			collection_id: 0,
 			nft_id: 0,
 		}));
+		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 1);
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
 			ALICE,
@@ -99,6 +100,7 @@ fn mint_nft_works() {
 			Some(Permill::from_float(20.525)),
 			bvec![0u8; 20]
 		));
+		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 3);
 		assert_noop!(
 			RMRKCore::mint_nft(
 				Origin::signed(ALICE),
@@ -394,6 +396,7 @@ fn change_issuer_works() {
 fn burn_nft_works() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(basic_collection());
+		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 0);
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
 			ALICE,
@@ -402,7 +405,9 @@ fn burn_nft_works() {
 			Some(Permill::from_float(0.0)),
 			bvec![0u8; 20]
 		));
+		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 1);
 		assert_ok!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, NFT_ID_0));
+		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 0);
 		assert_eq!(RMRKCore::nfts(COLLECTION_ID_0, NFT_ID_0).is_none(), true);
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NFTBurned {
 			owner: ALICE,

--- a/traits/src/collection.rs
+++ b/traits/src/collection.rs
@@ -15,6 +15,7 @@ pub struct CollectionInfo<BoundedString, AccountId> {
 	pub metadata: BoundedString,
 	pub max: u32,
 	pub symbol: BoundedString,
+	pub nfts_count: u32,
 }
 
 /// Abstraction over a Collection system.


### PR DESCRIPTION
Add `nfts_count` counter to `collection`. Increment during `mint_nft`, decrement during `burn_nft`

Changes in `src/lib.rs` purely formatting from cargo fmt
Fixes #37