### PR TITLE
Tidy and comment tests.rs

### DIFF
--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -589,7 +589,7 @@ fn create_resource_works() {
 	});
 }
 
-/// Resource: Resource addition with pending (RMRK2.0 spec: RESADD)
+/// Resource: Resource addition with pending and accept (RMRK2.0 spec: ACCEPT)
 #[test]
 fn add_resource_pending_works() {
 	ExtBuilder::default().build().execute_with(|| {
@@ -611,36 +611,16 @@ fn add_resource_pending_works() {
 		));
 		// Since BOB doesn't root-own NFT, resource's pending status should be true
 		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, true);
-	});
-}
-
-//ACCEPT (resource)
-#[test]
-fn accept_resource_works() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(basic_collection());
-		assert_ok!(basic_mint());
-		assert_ok!(RMRKCore::add_resource(
-			Origin::signed(BOB),
-			0,
-			0,
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-		));
-		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, true);
-		// Bob can't accept Alice's NFT's resource
+		// BOB doesn't own ALICES's NFT, so accept should fail
 		assert_noop!(RMRKCore::accept(Origin::signed(BOB), 0, 0, 0), Error::<Test>::NoPermission);
-		// Alice can accept her own NFT's resource
+		// ALICE can accept her own NFT's pending resource
 		assert_ok!(RMRKCore::accept(Origin::signed(ALICE), 0, 0, 0));
+		// Valid resource acceptance should trigger a ResourceAccepted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAccepted {
 			nft_id: 0,
 			resource_id: 0,
 		}));
-		// Resource should now be pending = false
+		// Resource should now have false pending status
 		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, false);
 	});
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -159,17 +159,21 @@ fn change_issuer_works() {
 	});
 }
 
-//MINT (nft)
+/// NFT: Basic Mint tests (RMRK2.0 spec: MINT)
 #[test]
 fn mint_nft_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Mint an NFT
 		assert_ok!(basic_mint());
+		// Minting an NFT should trigger an NftMinted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NftMinted {
 			owner: ALICE,
 			collection_id: 0,
 			nft_id: 0,
 		}));
+		// Minting an NFT should cause nfts_count to increase to 1
 		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 1);
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
@@ -179,6 +183,7 @@ fn mint_nft_works() {
 			Some(Permill::from_float(20.525)),
 			bvec![0u8; 20]
 		));
+		//TODO BOB shouldn't be able to mint in ALICE's collection?!
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(BOB),
 			BOB,

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -207,7 +207,7 @@ fn mint_nft_works() {
 	});
 }
 
-//MINT (nft)
+/// NFT: Mint tests with max (RMRK2.0 spec: MINT)
 #[test]
 fn mint_collection_max_logic_works() {
 	ExtBuilder::default().build().execute_with(|| {

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -165,6 +165,8 @@ fn mint_nft_works() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Collection nfts_count should be 0 prior to minting
+		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 0);
 		// Mint an NFT
 		assert_ok!(basic_mint());
 		// Minting an NFT should trigger an NftMinted event
@@ -461,12 +463,12 @@ fn send_to_grandchild_fails() {
 	});
 }
 
-//BURN (nft)
+/// NFT: Burn simple tests (RMRK2.0 spec: BURN)
 #[test]
 fn burn_nft_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
-		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 0);
 		assert_ok!(basic_mint());
 
 		assert_noop!(RMRKCore::burn_nft(Origin::signed(BOB), COLLECTION_ID_0, NFT_ID_0), Error::<Test>::NoPermission);

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -232,21 +232,6 @@ fn mint_collection_max_logic_works() {
 	});
 }
 
-//MINT (nft)
-#[test]
-fn mint_beyond_collection_max_fails() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(basic_collection());
-		for _ in 0..5 {
-			assert_ok!(basic_mint());
-		}
-		assert_noop!(
-			basic_mint(),
-			Error::<Test>::CollectionFullOrLocked
-		);
-	});
-}
-
 //SEND (nft)
 #[test]
 fn send_nft_to_minted_nft_works() {

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -38,17 +38,6 @@ fn basic_collection() -> DispatchResult {
 fn create_collection_works() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(basic_collection());
-		// FIXME: panick
-		// assert_noop!(
-		// 	RMRKCore::create_collection(
-		// 		Origin::signed(ALICE),
-		// 		bvec![0; <Test as UNQ::Config>::StringLimit::get() as usize + 1],
-		// 		None,
-		// 		bvec![0u8; 10],
-		// 	),
-		// 	Error::<Test>::TooLong
-		// );
-		// NextCollectionId::<Test>::mutate(|id| *id = <Test as UNQ::Config>::ClassId::max_value());
 		CollectionIndex::<Test>::mutate(|id| *id = CollectionId::max_value());
 		assert_noop!(
 			RMRKCore::create_collection(

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -35,10 +35,14 @@ fn basic_collection() -> DispatchResult {
 	RMRKCore::create_collection(Origin::signed(ALICE), bvec![0u8; 20], Some(5), bvec![0u8; 15])
 }
 #[test]
+// Basic Collection tests
 fn create_collection_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Reassign CollectionIndex to max value
 		CollectionIndex::<Test>::mutate(|id| *id = CollectionId::max_value());
+		// Creating collection above max_value should fail
 		assert_noop!(
 			RMRKCore::create_collection(
 				Origin::signed(ALICE),
@@ -48,6 +52,7 @@ fn create_collection_works() {
 			),
 			Error::<Test>::NoAvailableCollectionId
 		);
+		// Check for event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::CollectionCreated {
 			issuer: ALICE,
 			collection_id: 0,

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -589,12 +589,15 @@ fn create_resource_works() {
 	});
 }
 
-//RESADD (resource)
+/// Resource: Resource addition with pending (RMRK2.0 spec: RESADD)
 #[test]
 fn add_resource_pending_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Mint NFT
 		assert_ok!(basic_mint());
+		// BOB adds a resource to ALICE's NFT
 		assert_ok!(RMRKCore::add_resource(
 			Origin::signed(BOB),
 			0,
@@ -606,6 +609,7 @@ fn add_resource_pending_works() {
 			Some(bvec![0u8; 20]),
 			Some(bvec![0u8; 20]),
 		));
+		// Since BOB doesn't root-own NFT, resource's pending status should be true
 		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, true);
 	});
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -355,39 +355,34 @@ fn send_nft_to_minted_nft_works() {
 	});
 }
 
-//SEND (nft)
+/// NFT: Send tests, siblings (RMRK2.0 spec: SEND)
 #[test]
 fn send_two_nfts_to_same_nft_creates_two_children() {
 	ExtBuilder::default().build().execute_with(|| {
-		// let nft_metadata = bvec![0u8; 20];
+		// Create a basic collection
 		assert_ok!(basic_collection());
-		// Alice mints NFT (0, 0)
-		assert_ok!(basic_mint());
-		// Alice mints NFT (0, 1)
-		assert_ok!(basic_mint());
-		// Alice mints NFT (0, 2)
-		assert_ok!(basic_mint());
+		// Mint NFTs (0, 0), (0, 1), (0, 2)
+		for _ in 0..3 {
+			assert_ok!(basic_mint());
+		}
 
-		// Alice sends NFT (0, 1) to NFT (0, 0)
+		// ALICE sends NFT (0, 1) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			1,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
-
-		// Check NFT (0,0) has NFT (0,1) in Children StorageMap
+		// NFT (0,0) has NFT (0,1) in Children StorageMap
 		assert_eq!(RMRKCore::children((0, 0)), vec![(0,1)]);
-
-		// Alice sends NFT (0, 2) to NFT (0, 0)
+		// ALICE sends NFT (0, 2) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			2,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
-
-		// Check NFT (0,0) has NFT (0,1) & (0,2) in Children StorageMap
+		// NFT (0,0) has NFT (0,1) & (0,2) in Children StorageMap
 		assert_eq!(RMRKCore::children((0, 0)), vec![(0,1), (0,2)]);
 	});
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -365,7 +365,6 @@ fn send_two_nfts_to_same_nft_creates_two_children() {
 		for _ in 0..3 {
 			assert_ok!(basic_mint());
 		}
-
 		// ALICE sends NFT (0, 1) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -552,6 +552,21 @@ fn create_resource_works() {
 		assert_ok!(basic_collection());
 		// Mint NFT
 		assert_ok!(basic_mint());
+		// Adding an empty resource should fail
+		assert_noop!(
+			RMRKCore::add_resource(
+				Origin::signed(ALICE),
+				COLLECTION_ID_0,
+				NFT_ID_0,
+				None,
+				None,
+				None,
+				None,
+				None,
+				None
+			),
+			Error::<Test>::EmptyResource
+		);
 		// Add resource to NFT
 		assert_ok!(RMRKCore::add_resource(
 			Origin::signed(ALICE),
@@ -571,29 +586,6 @@ fn create_resource_works() {
 		}));
 		// Since ALICE rootowns NFT, pending status of resource should be false
 		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, false);
-	});
-}
-
-//RESADD (resource)
-#[test]
-fn create_empty_resource_fails() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(basic_collection());
-		assert_ok!(basic_mint());
-		assert_noop!(
-			RMRKCore::add_resource(
-				Origin::signed(ALICE),
-				COLLECTION_ID_0,
-				NFT_ID_0,
-				None,
-				None,
-				None,
-				None,
-				None,
-				None
-			),
-			Error::<Test>::EmptyResource
-		);
 	});
 }
 

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -625,14 +625,19 @@ fn add_resource_pending_works() {
 	});
 }
 
-//SETPROPERTY (property)
+/// Property: Setting property tests (RMRK2.0 spec: SETPROPERTY)
 #[test]
 fn set_property_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Define property key
 		let key = stbk("test-key");
+		// Define property value
 		let value = stb("test-value");
+		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Mint NFT
 		assert_ok!(basic_mint());
+		// ALICE sets property on NFT
 		assert_ok!(RMRKCore::set_property(
 			Origin::signed(ALICE),
 			0,
@@ -640,13 +645,16 @@ fn set_property_works() {
 			key.clone(),
 			value.clone()
 		));
+		// Successful property setting should trigger a PropertySet event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::PropertySet {
 			collection_id: 0,
 			maybe_nft_id: Some(0),
 			key: key.clone(),
 			value: value.clone(),
 		}));
-		// Error when set_property with BOB
+		// Property value now exists
+		assert_eq!(RMRKCore::properties((0, Some(0), key)).unwrap(), value);
+		// BOB does not own NFT so attempt to set property should fail
 		assert_noop!(RMRKCore::set_property(
 			Origin::signed(BOB),
 			0,
@@ -656,7 +664,6 @@ fn set_property_works() {
 			),
 			Error::<Test>::NoPermission
 		);
-		assert_eq!(RMRKCore::properties((0, Some(0), key)).unwrap(), value);
 	});
 }
 

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -31,6 +31,12 @@ macro_rules! bvec {
 	}
 }
 
+// issuer: T::AccountId,
+// 		metadata: StringLimitOf<T>,
+// 		max: u32,
+// 		symbol: StringLimitOf
+
+/// Shortcut for a test collection creation (Alice is issue, max NFTs is 5)
 fn basic_collection() -> DispatchResult {
 	RMRKCore::create_collection(Origin::signed(ALICE), bvec![0u8; 20], Some(5), bvec![0u8; 15])
 }
@@ -42,16 +48,20 @@ fn basic_collection() -> DispatchResult {
 // Property: set
 // Priority: set
 
-//CREATE (collection)
+/// Collection: Basic collection tests (RMRK2.0 spec: CREATE)
 #[test]
-// Basic Collection tests
 fn create_collection_works() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Creating collection should trigger CollectionCreated event
+		System::assert_last_event(MockEvent::RmrkCore(crate::Event::CollectionCreated {
+			issuer: ALICE,
+			collection_id: 0,
+		}));
 		// Reassign CollectionIndex to max value
 		CollectionIndex::<Test>::mutate(|id| *id = CollectionId::max_value());
-		// Creating collection above max_value should fail
+		// Creating collection above max_value of CollectionId (4294967295) should fail
 		assert_noop!(
 			RMRKCore::create_collection(
 				Origin::signed(ALICE),
@@ -60,12 +70,7 @@ fn create_collection_works() {
 				bvec![0u8; 15],
 			),
 			Error::<Test>::NoAvailableCollectionId
-		);
-		// Check for event
-		System::assert_last_event(MockEvent::RmrkCore(crate::Event::CollectionCreated {
-			issuer: ALICE,
-			collection_id: 0,
-		}));
+		);	
 	});
 }
 
@@ -128,6 +133,7 @@ fn destroy_collection_works() {
 		}));
 	});
 }
+
 
 //CHANGEISSUER (collection)
 #[test]

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -424,17 +424,16 @@ fn send_nft_removes_existing_parent() {
 	});
 }
 
-//SEND (nft)
+/// NFT: Send tests, multi-generational circular testing (RMRK2.0 spec: SEND)
 #[test]
 fn send_to_grandchild_fails() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
-		// Alice mints (0, 0)
-		assert_ok!(basic_mint());
-		// Alice mints (0, 1)
-		assert_ok!(basic_mint());
-		// Alice mints (0, 2)
-		assert_ok!(basic_mint());
+		// Mint NFTs (0, 0), (0, 1), (0, 2)
+		for _ in 0..3 {
+			assert_ok!(basic_mint());
+		}
 		// Alice sends NFT (0, 1) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
@@ -449,8 +448,7 @@ fn send_to_grandchild_fails() {
 			2,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 1),
 		));
-
-		// Alice sends (0, 0) to (0, 2)
+		// Sending NFT to its own grandchild should fail
 		assert_noop!(
 			RMRKCore::send(
 				Origin::signed(ALICE),

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -115,18 +115,24 @@ fn lock_collection_works() {
 	});
 }
 
-//DESTROY (collection)
+/// Collection: Destroy collection tests (RMRK2.0 spec: doesn't exist)
 #[test]
 fn destroy_collection_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection (has 5 max)
 		assert_ok!(basic_collection());
+		// Mint an NFT
 		assert_ok!(basic_mint());
+		// Non-empty collection should not be able to be destroyed
 		assert_noop!(
 			RMRKCore::destroy_collection(Origin::signed(ALICE), COLLECTION_ID_0),
 			Error::<Test>::CollectionNotEmpty
 		);
+		// Burn the single NFT in collection
 		assert_ok!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, NFT_ID_0));
+		// Empty collection can be destroyed
 		assert_ok!(RMRKCore::destroy_collection(Origin::signed(ALICE), COLLECTION_ID_0));
+		// Destroy event is triggered by successful destroy_collection
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::CollectionDestroyed {
 			issuer: ALICE,
 			collection_id: COLLECTION_ID_0,

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -489,45 +489,42 @@ fn burn_nft_works() {
 	});
 }
 
-//BURN (nft)
+/// NFT: Burn complex multi-generational tests (RMRK2.0 spec: BURN)
 #[test]
 fn burn_nft_with_great_grandchildren_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
-		// Alice mints (0, 0)
-		assert_ok!(basic_mint());
-		// Alice mints (0, 1)
-		assert_ok!(basic_mint());
-		// Alice mints (0, 2)
-		assert_ok!(basic_mint());
-		// Alice mints (0, 3)
-		assert_ok!(basic_mint());
-		// Alice sends NFT (0, 1) to NFT (0, 0)
+		// Mint NFTs (0, 0), (0, 1), (0, 2), (0, 3)
+		for _ in 0..4 {
+			assert_ok!(basic_mint());
+		}
+		// ALICE sends NFT (0, 1) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			1,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
-		// Alice sends NFT (0, 2) to NFT (0, 1)
+		// ALICE sends NFT (0, 2) to NFT (0, 1)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			2,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 1),
 		));
-		// Alice sends NFT (0, 3) to NFT (0, 2)
+		// ALICE sends NFT (0, 3) to NFT (0, 2)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			3,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 2),
 		));
-		// Child is alive
+		// Great-grandchild NFT (0, 3) exists
 		assert_eq!(RMRKCore::nfts(COLLECTION_ID_0, 3).is_some(), true);
-		// Burn great-grandfather
+		// Burn great-grandparent NFT (0, 0)
 		assert_ok!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, NFT_ID_0));
-		// Child is dead
+		// Great-grandchild NFT (0, 3) is dead :'-(
 		assert!(RMRKCore::nfts(COLLECTION_ID_0, 3).is_none())
 	});
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -386,48 +386,40 @@ fn send_two_nfts_to_same_nft_creates_two_children() {
 	});
 }
 
-//SEND (nft)
+/// NFT: Send tests, removing parent (RMRK2.0 spec: SEND)
 #[test]
 fn send_nft_removes_existing_parent() {
 	ExtBuilder::default().build().execute_with(|| {
-		// let nft_metadata = bvec![0u8; 20];
+		// Create a basic collection
 		assert_ok!(basic_collection());
-		// Alice mints NFT (0, 0)
-		assert_ok!(basic_mint());
-		// Alice mints NFT (0, 1)
-		assert_ok!(basic_mint());
-		// Alice mints NFT (0, 2)
-		assert_ok!(basic_mint());
-		// Alice mints NFT (0, 3)
-		assert_ok!(basic_mint());
-
-		// Alice sends NFT (0, 1) to NFT (0, 0)
+		// Mint NFTs (0, 0), (0, 1), (0, 2), (0, 3)
+		for _ in 0..4 {
+			assert_ok!(basic_mint());
+		}
+		// ALICE sends NFT (0, 1) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			1,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
-		// Alice sends NFT (0, 2) to NFT (0, 0)
+		// ALICE sends NFT (0, 2) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			2,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
-
 		// NFT (0, 0) is parent of NFT (0, 1)
 		assert_eq!(RMRKCore::children((0, 0)), vec![(0, 1), (0, 2)]);
-
-		// Alice sends NFT (0, 1) to NFT (0, 2)
+		// ALICE sends NFT (0, 1) to NFT (0, 2)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
 			0,
 			1,
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 2),
 		));
-
-		// NFT (0, 0) is not parent of NFT (0, 1)
+		// NFT (0, 0) is no longer parent of NFT (0, 1)
 		assert_eq!(RMRKCore::children((0, 0)), vec![(0, 2)]);
 	});
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -211,14 +211,20 @@ fn mint_nft_works() {
 #[test]
 fn mint_collection_max_logic_works() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert_ok!(RMRKCore::create_collection(
-			Origin::signed(ALICE),
-			bvec![0u8; 20],
-			Some(1),
-			bvec![0u8; 15]
-		));
-		assert_ok!(basic_mint());
+		// Create a basic collection
+		assert_ok!(basic_collection());
+		// Mint 5 NFTs (filling collection)
+		for _ in 0..5 {
+			assert_ok!(basic_mint());
+		}
+		// Minting beyond collection max (5) should fail
+		assert_noop!(
+			basic_mint(),
+			Error::<Test>::CollectionFullOrLocked
+		);
+		// Burn an NFT
 		assert_ok!(RMRKCore::burn_nft(Origin::signed(ALICE), COLLECTION_ID_0, 0));
+		// Minting should still fail, as burning should not affect "fullness" of collection
 		assert_noop!(
 			basic_mint(),
 			Error::<Test>::CollectionFullOrLocked

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -529,11 +529,11 @@ fn burn_nft_with_great_grandchildren_works() {
 	});
 }
 
-//RESADD (resource)
+/// Resource: Basic resource addition (RMRK2.0 spec: RESADD)
 #[test]
 fn create_resource_works() {
 	ExtBuilder::default().build().execute_with(|| {
-		// Creating a resource for non-existent NFT fails
+		// Adding a resource to non-existent NFT should fail
 		assert_noop!(
 			RMRKCore::add_resource(
 				Origin::signed(ALICE),
@@ -548,10 +548,11 @@ fn create_resource_works() {
 			),
 			Error::<Test>::NoAvailableNftId
 		);
-		// Create collection and NFT
+		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Mint NFT
 		assert_ok!(basic_mint());
-		// Add resource works
+		// Add resource to NFT
 		assert_ok!(RMRKCore::add_resource(
 			Origin::signed(ALICE),
 			0,
@@ -563,11 +564,12 @@ fn create_resource_works() {
 			Some(bvec![0u8; 20]),
 			Some(bvec![0u8; 20]),
 		));
+		// Successful resource addition should trigger ResourceAdded event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAdded {
 			nft_id: 0,
 			resource_id: 0,
 		}));
-		// Since ALICE rootowns NFT (0, 0), pending should be false
+		// Since ALICE rootowns NFT, pending status of resource should be false
 		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, false);
 	});
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -667,32 +667,30 @@ fn set_property_works() {
 	});
 }
 
-//SETPRIORITY (priority)
+/// Priority: Setting priority tests (RMRK2.0 spec: SETPRIORITY)
 #[test]
 fn set_priority_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Mint NFT
 		assert_ok!(basic_mint());
+		// ALICE sets priority on NFT
 		assert_ok!(RMRKCore::set_priority(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
 			vec![stv("hello"), stv("world")]
 		));
+		// Successful priority set should trigger PrioritySet event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::PrioritySet {
 			collection_id: 0,
 			nft_id: 0,
 		}));
+		// Priorities exist
 		assert_eq!(
 			RMRKCore::priorities(COLLECTION_ID_0, NFT_ID_0).unwrap(),
 			vec![stv("hello"), stv("world")]
 		);
 	});
 }
-
-
-
-// #[test]
-// TODO fn cannot send to its own descendent?  this should be easy enough to check
-// TODO fn cannot send to its own grandparent?  this seems difficult to check without implementing a
-// new Parent storage struct

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -140,18 +140,21 @@ fn destroy_collection_works() {
 	});
 }
 
-
-//CHANGEISSUER (collection)
+/// Collection: Change issuer tests (RMRK2.0 spec: CHANGEISSUER)=
 #[test]
 fn change_issuer_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
 		assert_ok!(basic_collection());
+		// Change issuer from ALICE to BOB
 		assert_ok!(RMRKCore::change_issuer(Origin::signed(ALICE), 0, BOB));
+		// Changing issuer should trigger IssuerChanged event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::IssuerChanged {
 			old_issuer: ALICE,
 			new_issuer: BOB,
 			collection_id: 0,
 		}));
+		// New issuer should be Bob
 		assert_eq!(RMRKCore::collections(0).unwrap().issuer, BOB);
 	});
 }

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -653,7 +653,7 @@ fn set_property_works() {
 			value: value.clone(),
 		}));
 		// Property value now exists
-		assert_eq!(RMRKCore::properties((0, Some(0), key)).unwrap(), value);
+		assert_eq!(RMRKCore::properties((0, Some(0), key.clone())).unwrap(), value.clone());
 		// BOB does not own NFT so attempt to set property should fail
 		assert_noop!(RMRKCore::set_property(
 			Origin::signed(BOB),


### PR DESCRIPTION
mostly just
- reorders so like-with-like (order is collection, nft, resource, property, priority)
- adds comments all over
- adds a basic_mint() function to reduce redundancy
- some consolidation of tests