### PR TITLE
Bug/93 update vec to bounded vec

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -56,7 +56,12 @@ where
 	}
 }
 
-impl<T: Config> Resource<BoundedVec<u8, T::StringLimit>, T::AccountId, BoundedResource<T::ResourceSymbolLimit>> for Pallet<T>
+impl<T: Config> Resource<
+	BoundedVec<u8, T::StringLimit>,
+	T::AccountId,
+	BoundedResource<T::ResourceSymbolLimit>,
+	BoundedVec<PartId, T::PartsLimit>
+	> for Pallet<T>
 where
 	T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
 {
@@ -71,7 +76,7 @@ where
 		slot: Option<SlotId>,
 		license: Option<BoundedVec<u8, T::StringLimit>>,
 		thumb: Option<BoundedVec<u8, T::StringLimit>>,
-		parts: Option<Vec<PartId>>,
+		parts: Option<BoundedVec<PartId, T::PartsLimit>>,
 	) -> DispatchResult {
 		let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
 
@@ -82,7 +87,11 @@ where
 				thumb.is_none();
 		ensure!(!empty, Error::<T>::EmptyResource);
 
-		let res = ResourceInfo::<BoundedVec<u8, T::ResourceSymbolLimit>, BoundedVec<u8, T::StringLimit>> {
+		let res = ResourceInfo::<
+			BoundedVec<u8, T::ResourceSymbolLimit>,
+			BoundedVec<u8, T::StringLimit>,
+			BoundedVec<PartId, T::PartsLimit>
+			> {
 			id: resource_id.clone(),
 			base,
 			src,

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -528,19 +528,6 @@ where
 		Children::<T>::remove((parent.0, parent.1), (child.0, child.1));
 	}
 
-	/// I don't think we use this at all? [delete this statement if i'm wrong or this function if not]
-	/// Has a child NFT present in the Children StorageMap of the parent NFT
-	///
-	/// Parameters:
-	/// - `collection_id`: Collection ID of the NFT to lookup the root owner
-	/// - `nft_id`: NFT ID that is to be looked up for the root owner
-	///
-	/// Output:
-	/// - `bool`
-	pub fn has_child(parent: (CollectionId, NftId)) -> bool {
-		Children::<T>::iter_prefix_values(parent).count() != 0
-	}
-
 	/// Check whether a NFT is descends from a suspected parent NFT
 	/// and return a `bool` if NFT is or not
 	///
@@ -581,29 +568,7 @@ where
 				found_child
 			},
 		}
-	}
-
-	/// I don't think we use this at all? [delete this line if untrue, or this function if true]
-	/// `recursive_burn` function will recursively call itself to burn the NFT and all the children
-	/// of the NFT. Any caller functions must be #[transactional]
-	///
-	/// Parameters:
-	/// - `collection_id`: Collection ID of the NFT to be burned
-	/// - `nft_id`: NFT ID that is to be burned
-	/// - `max_recursion`: Maximum number of recursion allowed
-	pub fn recursive_burn(
-		collection_id: CollectionId,
-		nft_id: NftId,
-		max_recursions: u32,
-	) -> DispatchResult {
-		ensure!(max_recursions > 0, Error::<T>::TooManyRecursions);
-		Nfts::<T>::remove(collection_id, nft_id);
-
-		for ((child_collection_id, child_nft_id), _) in Children::<T>::iter_prefix((collection_id, nft_id,)) {
-			Pallet::<T>::recursive_burn(child_collection_id, child_nft_id, max_recursions - 1)?;
-		}
-		Ok(())
-	}
+	}	
 
 	pub fn get_next_nft_id(collection_id: CollectionId) -> Result<NftId, Error<T>> {
 		NextNftId::<T>::try_mutate(collection_id, |id| {

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -605,19 +605,6 @@ where
 		Ok(())
 	}
 
-	pub fn to_bounded_string(name: Vec<u8>) -> Result<BoundedVec<u8, T::StringLimit>, Error<T>> {
-		name.try_into().map_err(|_| Error::<T>::TooLong)
-	}
-
-	pub fn to_optional_bounded_string(
-		name: Option<Vec<u8>>,
-	) -> Result<Option<BoundedVec<u8, T::StringLimit>>, Error<T>> {
-		Ok(match name {
-			Some(n) => Some(Self::to_bounded_string(n)?),
-			None => None,
-		})
-	}
-
 	pub fn get_next_nft_id(collection_id: CollectionId) -> Result<NftId, Error<T>> {
 		NextNftId::<T>::try_mutate(collection_id, |id| {
 			let current_id = *id;

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -320,7 +320,7 @@ where
 		for _ in Resources::<T>::drain_prefix((collection_id, nft_id)) {}
 
 		for ((child_collection_id, child_nft_id), _) in Children::<T>::iter_prefix((collection_id, nft_id,)) {
-			Pallet::<T>::remove_child((collection_id, nft_id), (child_collection_id, child_nft_id));
+			for _ in Children::<T>::drain_prefix((collection_id, nft_id)) {}
 			Self::nft_burn(child_collection_id, child_nft_id, max_recursions - 1)?;
 		}
 

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -220,7 +220,7 @@ where
 		let nft = NftInfo { owner: owner_as_maybe_account, recipient, royalty, metadata, equipped: false };
 
 		Nfts::<T>::insert(collection_id, nft_id, nft);
-		NftsByOwner::<T>::append(owner, (collection_id, nft_id));
+		NftsByOwner::<T>::insert((&owner, &collection_id, &nft_id), ());
 
 		// increment nfts counter
 		let nfts_count = collection.nfts_count.checked_add(1).ok_or(ArithmeticError::Overflow)?;

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -319,7 +319,6 @@ where
 
 		for _ in Resources::<T>::drain_prefix((collection_id, nft_id)) {}
 
-		let c = Children::<T>::iter_prefix((collection_id, nft_id,)).count();
 		for ((child_collection_id, child_nft_id), _) in Children::<T>::iter_prefix((collection_id, nft_id,)) {
 			Pallet::<T>::remove_child((collection_id, nft_id), (child_collection_id, child_nft_id));
 			Self::nft_burn(child_collection_id, child_nft_id, max_recursions - 1)?;

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -36,9 +36,6 @@ pub type ResourceOf<T, R, P> = ResourceInfo::<
 
 pub type BoundedCollectionSymbolOf<T> = BoundedVec<u8, <T as Config>::CollectionSymbolLimit>;
 
-// pub type ResourceOf<T, R> =
-// 	ResourceInfo<BoundedVec<u8, R>, BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>>;
-
 pub type StringLimitOf<T> = BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>;
 
 pub type BoundedResource<R> = BoundedVec<u8, R>;

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -94,8 +94,16 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn get_nfts_by_owner)]
 	/// Stores collections info
-	pub type NftsByOwner<T: Config> =
-		StorageMap<_, Twox64Concat, T::AccountId, Vec<(CollectionId, NftId)>>;
+	pub type NftsByOwner<T: Config> = StorageNMap<
+		_,
+		(
+			NMapKey<Blake2_128Concat, T::AccountId>,
+			NMapKey<Blake2_128Concat, CollectionId>,
+			NMapKey<Blake2_128Concat, NftId>,
+		),
+		(),
+		OptionQuery,
+	>;	
 
 	#[pallet::storage]
 	#[pallet::getter(fn nfts)]

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -30,7 +30,11 @@ pub type InstanceInfoOf<T> = NftInfo<
 	<T as frame_system::Config>::AccountId,
 	BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
 >;
-pub type ResourceOf<T, R> = ResourceInfo::<BoundedVec<u8, R>, BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>>;
+pub type ResourceOf<T, R, P> = ResourceInfo::<
+	BoundedVec<u8, R>,
+	BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
+	BoundedVec<PartId, P>
+	>;
 
 pub type StringLimitOf<T> = BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>;
 
@@ -62,6 +66,10 @@ pub mod pallet {
 		/// The maximum resource symbol length
 		#[pallet::constant]
 		type ResourceSymbolLimit: Get<u32>;
+
+		/// The maximum number of parts each resource may have
+		#[pallet::constant]
+		type PartsLimit: Get<u32>;
 	}
 
 	#[pallet::storage]
@@ -130,7 +138,7 @@ pub mod pallet {
 			NMapKey<Blake2_128Concat, BoundedResource<T::ResourceSymbolLimit>>
 			,
 		),
-		ResourceOf<T, T::ResourceSymbolLimit>,
+		ResourceOf<T, T::ResourceSymbolLimit, T::PartsLimit>,
 		OptionQuery,
 	>;
 
@@ -547,7 +555,7 @@ pub mod pallet {
 			slot: Option<SlotId>,
 			license: Option<BoundedVec<u8, T::StringLimit>>,
 			thumb: Option<BoundedVec<u8, T::StringLimit>>,
-			parts: Option<Vec<PartId>>,
+			parts: Option<BoundedVec<PartId, T::PartsLimit>>
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
 

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -138,11 +138,27 @@ pub mod pallet {
 
 
 
+	// #[pallet::storage]
+	// #[pallet::getter(fn children)]
+	// /// Stores nft children info
+	// pub type Children<T: Config> =
+	// 	StorageMap<_, Twox64Concat, (CollectionId, NftId), Vec<(CollectionId, NftId)>, ValueQuery>;
+
 	#[pallet::storage]
 	#[pallet::getter(fn children)]
 	/// Stores nft children info
-	pub type Children<T: Config> =
-		StorageMap<_, Twox64Concat, (CollectionId, NftId), Vec<(CollectionId, NftId)>, ValueQuery>;
+	pub type Children<T: Config> = StorageDoubleMap<_, Twox64Concat, (CollectionId, NftId), Twox64Concat, (CollectionId, NftId), ()>;
+	
+	// <
+	// 	_,
+	// 	(
+	// 		NMapKey<Blake2_128Concat, (CollectionId, NftId)>,
+	// 		NMapKey<Blake2_128Concat, CollectionId>,
+	// 		NMapKey<Blake2_128Concat, NftId>,
+	// 	),
+	// 	(),
+	// 	OptionQuery,
+	// >;
 
 	#[pallet::storage]
 	#[pallet::getter(fn resources)]
@@ -572,7 +588,7 @@ pub mod pallet {
 			slot: Option<SlotId>,
 			license: Option<BoundedVec<u8, T::StringLimit>>,
 			thumb: Option<BoundedVec<u8, T::StringLimit>>,
-			parts: Option<BoundedVec<PartId, T::PartsLimit>>
+			parts: Option<BoundedVec<PartId, T::PartsLimit>>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
 
@@ -587,7 +603,7 @@ pub mod pallet {
 				slot,
 				license,
 				thumb,
-				parts
+				parts,
 			)?;
 
 			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
@@ -604,7 +620,10 @@ pub mod pallet {
 			resource_id: BoundedResource<T::ResourceSymbolLimit>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
-			ensure!(Resources::<T>::get((collection_id, nft_id, resource_id.clone())).is_some(), Error::<T>::ResourceDoesntExist);
+			ensure!(
+				Resources::<T>::get((collection_id, nft_id, resource_id.clone())).is_some(),
+				Error::<T>::ResourceDoesntExist
+			);
 
 			let (owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
 			ensure!(owner == sender, Error::<T>::NoPermission);

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -8,7 +8,7 @@ use frame_support::{
 use frame_system::ensure_signed;
 
 use sp_runtime::{traits::StaticLookup, DispatchError, Permill};
-use sp_std::{convert::TryInto, vec::Vec};
+use sp_std::convert::TryInto;
 
 use rmrk_traits::{
 	primitives::*, AccountIdOrCollectionNftTuple, Collection, CollectionInfo, Nft, NftInfo,
@@ -136,30 +136,11 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
-
-
-	// #[pallet::storage]
-	// #[pallet::getter(fn children)]
-	// /// Stores nft children info
-	// pub type Children<T: Config> =
-	// 	StorageMap<_, Twox64Concat, (CollectionId, NftId), Vec<(CollectionId, NftId)>, ValueQuery>;
-
 	#[pallet::storage]
 	#[pallet::getter(fn children)]
 	/// Stores nft children info
 	pub type Children<T: Config> = StorageDoubleMap<_, Twox64Concat, (CollectionId, NftId), Twox64Concat, (CollectionId, NftId), ()>;
 	
-	// <
-	// 	_,
-	// 	(
-	// 		NMapKey<Blake2_128Concat, (CollectionId, NftId)>,
-	// 		NMapKey<Blake2_128Concat, CollectionId>,
-	// 		NMapKey<Blake2_128Concat, NftId>,
-	// 	),
-	// 	(),
-	// 	OptionQuery,
-	// >;
-
 	#[pallet::storage]
 	#[pallet::getter(fn resources)]
 	/// Stores resource info
@@ -190,7 +171,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::pallet]
-	#[pallet::without_storage_info]
 	#[pallet::generate_store(pub(super) trait Store)]
 	pub struct Pallet<T>(_);
 

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -43,6 +43,7 @@ parameter_types! {
 	pub MaxMetadataLength: u32 = 256;
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
+	pub const PartsLimit: u32 = 10;
 }
 
 impl pallet_rmrk_core::Config for Test {
@@ -51,6 +52,7 @@ impl pallet_rmrk_core::Config for Test {
 	type ProtocolOrigin = EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
 	type ResourceSymbolLimit = ResourceSymbolLimit;
+	type PartsLimit = PartsLimit;
 }
 
 parameter_types! {

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -44,6 +44,7 @@ parameter_types! {
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
 	pub const PartsLimit: u32 = 10;
+	pub const MaxPriorities: u32 = 3;
 }
 
 impl pallet_rmrk_core::Config for Test {
@@ -53,6 +54,7 @@ impl pallet_rmrk_core::Config for Test {
 	type MaxRecursions = MaxRecursions;
 	type ResourceSymbolLimit = ResourceSymbolLimit;
 	type PartsLimit = PartsLimit;
+	type MaxPriorities = MaxPriorities;
 }
 
 parameter_types! {
@@ -143,6 +145,9 @@ pub const COLLECTION_ID_0: <Test as pallet_uniques::Config>::ClassId = 0;
 // pub const COLLECTION_ID_1: <Test as pallet_uniques::Config>::ClassId = 1;
 pub const NFT_ID_0: <Test as pallet_uniques::Config>::InstanceId = 0;
 pub const NOT_EXISTING_CLASS_ID: <Test as pallet_uniques::Config>::ClassId = 999;
+pub const RESOURCE_ZERO: ResourceId = 0;
+pub const RESOURCE_ONE: ResourceId = 1;
+pub const RESOURCE_TWO: ResourceId = 2;
 
 pub struct ExtBuilder;
 impl Default for ExtBuilder {

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -43,7 +43,7 @@ parameter_types! {
 	pub MaxMetadataLength: u32 = 256;
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
-	pub const PartsLimit: u32 = 10;
+	pub const PartsLimit: u32 = 50;
 	pub const MaxPriorities: u32 = 3;
 }
 

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -350,7 +350,7 @@ fn send_nft_to_minted_nft_works() {
 		// Bob-rootowned NFT (0,1) [child] is owned by Bob-rootowned NFT (0,0) [parent]
 		assert_eq!(UNQ::Pallet::<Test>::owner(0, 1), Some(RMRKCore::nft_to_account_id(0, 0)),);
 		// NFT (0,0) has NFT (0,1) in Children StorageMap
-		assert_eq!(RMRKCore::children((0, 0)), vec![(0, 1)]);
+		assert!(RMRKCore::children((0, 0), (0, 1)).is_some());
 		// Attempt to send NFT to self should fail
 		assert_noop!(
 			RMRKCore::send(
@@ -468,7 +468,7 @@ fn send_two_nfts_to_same_nft_creates_two_children() {
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
 		// NFT (0,0) has NFT (0,1) in Children StorageMap
-		assert_eq!(RMRKCore::children((0, 0)), vec![(0, 1)]);
+		assert!(RMRKCore::children((0, 0), (0, 1)).is_some());
 		// ALICE sends NFT (0, 2) to NFT (0, 0)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
@@ -477,7 +477,8 @@ fn send_two_nfts_to_same_nft_creates_two_children() {
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
 		// NFT (0,0) has NFT (0,1) & (0,2) in Children StorageMap
-		assert_eq!(RMRKCore::children((0, 0)), vec![(0, 1), (0, 2)]);
+		assert!(RMRKCore::children((0, 0), (0,1)).is_some());
+		assert!(RMRKCore::children((0, 0), (0,2)).is_some());
 	});
 }
 
@@ -506,7 +507,8 @@ fn send_nft_removes_existing_parent() {
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
 		));
 		// NFT (0, 0) is parent of NFT (0, 1)
-		assert_eq!(RMRKCore::children((0, 0)), vec![(0, 1), (0, 2)]);
+		assert!(RMRKCore::children((0, 0), (0, 1)).is_some());
+		assert!(RMRKCore::children((0, 0), (0, 2)).is_some());
 		// ALICE sends NFT (0, 1) to NFT (0, 2)
 		assert_ok!(RMRKCore::send(
 			Origin::signed(ALICE),
@@ -515,7 +517,7 @@ fn send_nft_removes_existing_parent() {
 			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 2),
 		));
 		// NFT (0, 0) is no longer parent of NFT (0, 1)
-		assert_eq!(RMRKCore::children((0, 0)), vec![(0, 2)]);
+		assert!(RMRKCore::children((0, 0), (0, 1)).is_none());
 	});
 }
 

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -1,8 +1,4 @@
-use frame_support::{
-	assert_noop,
-	assert_ok,
-	// error::BadOrigin
-};
+use frame_support::{assert_noop, assert_ok};
 // use sp_runtime::AccountId32;
 use sp_runtime::Permill;
 // use crate::types::ClassType;
@@ -95,9 +91,12 @@ fn create_collection_works() {
 fn create_collection_no_max_works() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Create a collection with max of None
-		assert_ok!(
-			RMRKCore::create_collection(Origin::signed(ALICE), bvec![0u8; 20], None, bvec![0u8; 15])
-		);
+		assert_ok!(RMRKCore::create_collection(
+			Origin::signed(ALICE),
+			bvec![0u8; 20],
+			None,
+			bvec![0u8; 15]
+		));
 		// Creating collection should trigger CollectionCreated event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::CollectionCreated {
 			issuer: ALICE,
@@ -105,15 +104,13 @@ fn create_collection_no_max_works() {
 		}));
 		// Mint 100 NFTs
 		for _ in 0..100 {
-			assert_ok!(
-				basic_mint()
-			);
+			assert_ok!(basic_mint());
 		}
 		// Last event should be the 100th NFT creation
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NftMinted {
 			owner: ALICE,
 			collection_id: 0,
-			nft_id: 99
+			nft_id: 99,
 		}));
 	});
 }
@@ -595,8 +592,7 @@ fn burn_nft_works() {
 			None,
 			None,
 			None
-		));		
-
+		));
 
 		// Ensure resources are there
 		assert_eq!(Resources::<Test>::iter_prefix((COLLECTION_ID_0, NFT_ID_0)).count(), 2);
@@ -664,8 +660,8 @@ fn burn_nft_with_great_grandchildren_works() {
 			None,
 			None,
 			None
-		));			
-		
+		));
+
 		// Ensure resources are there
 		assert_eq!(Resources::<Test>::iter_prefix((COLLECTION_ID_0, 3)).count(), 2);
 
@@ -709,16 +705,16 @@ fn create_resource_works() {
 		assert_noop!(
 			RMRKCore::add_resource(
 				Origin::signed(ALICE),
-				0, // collection_id
-				0, // nft_id
+				0,             // collection_id
+				0,             // nft_id
 				stbr("res-1"), // resource_id
-				Some(0), // base_id
-				None, // src
-				None, // metadata
-				None, // slot
-				None, // license
-				None, // thumb
-				None, // parts
+				Some(0),       // base_id
+				None,          // src
+				None,          // metadata
+				None,          // slot
+				None,          // license
+				None,          // thumb
+				None,          // parts
 			),
 			Error::<Test>::NoAvailableNftId
 		);
@@ -733,13 +729,13 @@ fn create_resource_works() {
 				COLLECTION_ID_0,
 				NFT_ID_0,
 				stbr("res-2"), // resource_id
-				None, // base_id
-				None, // src
-				None, // metadata
-				None, // slot
-				None, // license
-				None, // thumb
-				None, // parts
+				None,          // base_id
+				None,          // src
+				None,          // metadata
+				None,          // slot
+				None,          // license
+				None,          // thumb
+				None,          // parts
 			),
 			Error::<Test>::EmptyResource
 		);
@@ -749,13 +745,13 @@ fn create_resource_works() {
 			COLLECTION_ID_0,
 			NFT_ID_0,
 			stbr("res-3"), // resource_id
-			Some(0), // base_id
-			None, // src
-			None, // metadata
-			None, // slot
-			None, // license
-			None, // thumb
-			None, // parts
+			Some(0),       // base_id
+			None,          // src
+			None,          // metadata
+			None,          // slot
+			None,          // license
+			None,          // thumb
+			None,          // parts
 		));
 		// Successful resource addition should trigger ResourceAdded event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAdded {
@@ -766,7 +762,6 @@ fn create_resource_works() {
 		assert_eq!(RMRKCore::resources((0, 0, stbr("res-3"))).unwrap().pending, false);
 	});
 }
-
 
 /// Resource: Resource addition with pending and accept (RMRK2.0 spec: ACCEPT)
 #[test]
@@ -782,20 +777,21 @@ fn add_resource_pending_works() {
 			COLLECTION_ID_0,
 			NFT_ID_0,
 			stbr("res-4"), // resource_id
-			Some(0), // base_id
-			None, // src
-			None, // metadata
-			None, // slot
-			None, // license
-			None, // thumb
-			None, // parts
+			Some(0),       // base_id
+			None,          // src
+			None,          // metadata
+			None,          // slot
+			None,          // license
+			None,          // thumb
+			None,          // parts
 		));
 		// Since BOB doesn't root-own NFT, resource's pending status should be true
 		assert_eq!(RMRKCore::resources((0, 0, stbr("res-4"))).unwrap().pending, true);
 		// BOB doesn't own ALICES's NFT, so accept should fail
 		assert_noop!(
 			RMRKCore::accept_resource(Origin::signed(BOB), 0, 0, stbr("res-4")),
-			Error::<Test>::NoPermission);
+			Error::<Test>::NoPermission
+		);
 		// ALICE can accept her own NFT's pending resource
 		assert_ok!(RMRKCore::accept_resource(Origin::signed(ALICE), 0, 0, stbr("res-4")));
 		// Valid resource acceptance should trigger a ResourceAccepted event
@@ -858,17 +854,29 @@ fn set_priority_works() {
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			vec![stv("hello"), stv("world")]
+			bvec![100, 500] // BoundedVec Resource 0, 1
 		));
 		// Successful priority set should trigger PrioritySet event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::PrioritySet {
 			collection_id: 0,
 			nft_id: 0,
 		}));
-		// Priorities exist
-		assert_eq!(
-			RMRKCore::priorities(COLLECTION_ID_0, NFT_ID_0).unwrap(),
-			vec![stv("hello"), stv("world")]
-		);
+		// Resource 100 should have priority 0
+		assert_eq!(RMRKCore::priorities((COLLECTION_ID_0, NFT_ID_0, 100)).unwrap(), 0);
+		// Resource 500 should have priority 1
+		assert_eq!(RMRKCore::priorities((COLLECTION_ID_0, NFT_ID_0, 500)).unwrap(), 1);
+		// Setting priority again drains and resets priorities
+		assert_ok!(RMRKCore::set_priority(
+			Origin::signed(ALICE),
+			COLLECTION_ID_0,
+			NFT_ID_0,
+			bvec![1000, 100] // BoundedVec Resources 2, 0
+		));
+		// Priorities reset, resource 100 should have priority one
+		assert_eq!(RMRKCore::priorities((COLLECTION_ID_0, NFT_ID_0, 100)).unwrap(), 1);
+		// Resource 1000 should have priority zero
+		assert_eq!(RMRKCore::priorities((COLLECTION_ID_0, NFT_ID_0, 1000)).unwrap(), 0);
+		// Resource 500 should no longer have a priority
+		assert!(RMRKCore::priorities((COLLECTION_ID_0, NFT_ID_0, 500)).is_none(),);
 	});
 }

--- a/pallets/rmrk-equip/src/functions.rs
+++ b/pallets/rmrk-equip/src/functions.rs
@@ -25,7 +25,10 @@ impl<T: Config> Base<
 	CollectionId,
 	NftId,
 	StringLimitOf<T>,
-	BoundedVec<PartType<StringLimitOf<T>>, T::PartsLimit>> for Pallet<T>
+	BoundedVec<PartType<StringLimitOf<T>, BoundedVec<CollectionId, T::MaxCollectionsEquippablePerPart>>,
+	T::PartsLimit>,
+	BoundedVec<CollectionId, T::MaxCollectionsEquippablePerPart>
+	> for Pallet<T>
 where
 	T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
 {
@@ -33,7 +36,7 @@ where
 		issuer: T::AccountId,
 		base_type: StringLimitOf<T>,
 		symbol: StringLimitOf<T>,
-		parts: BoundedVec<PartType<StringLimitOf<T>>, T::PartsLimit>,
+		parts: BoundedVec<PartType<StringLimitOf<T>, BoundedVec<CollectionId, T::MaxCollectionsEquippablePerPart>>, T::PartsLimit>,
 	) -> Result<BaseId, DispatchError> {
 		let base_id = Self::get_next_base_id()?;
 		for part in parts.clone() {
@@ -238,7 +241,7 @@ where
 		issuer: T::AccountId,
 		base_id: BaseId,
 		part_id: PartId,
-		equippables: EquippableList,
+		equippables: EquippableList<BoundedVec<CollectionId, T::MaxCollectionsEquippablePerPart>>,
 	) -> Result<(BaseId, SlotId), DispatchError> {
 		// Base must exist
 		ensure!(Bases::<T>::get(base_id).is_some(), Error::<T>::BaseDoesntExist);

--- a/pallets/rmrk-equip/src/functions.rs
+++ b/pallets/rmrk-equip/src/functions.rs
@@ -20,7 +20,12 @@ impl<T: Config> Pallet<T> {
 	}
 }
 
-impl<T: Config> Base<T::AccountId, CollectionId, NftId, StringLimitOf<T>> for Pallet<T>
+impl<T: Config> Base<
+	T::AccountId,
+	CollectionId,
+	NftId,
+	StringLimitOf<T>,
+	BoundedVec<PartType<StringLimitOf<T>>, T::PartsLimit>> for Pallet<T>
 where
 	T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
 {
@@ -28,7 +33,7 @@ where
 		issuer: T::AccountId,
 		base_type: StringLimitOf<T>,
 		symbol: StringLimitOf<T>,
-		parts: Vec<PartType<StringLimitOf<T>>>,
+		parts: BoundedVec<PartType<StringLimitOf<T>>, T::PartsLimit>,
 	) -> Result<BaseId, DispatchError> {
 		let base_id = Self::get_next_base_id()?;
 		for part in parts.clone() {

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -40,10 +40,6 @@ pub mod pallet {
 	pub trait Config: frame_system::Config + pallet_rmrk_core::Config {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
-		// No longer needed as we use PartsLimit in BoundedVec now
-		// #[pallet::constant]
-		// type MaxPartsPerBase: Get<u32>;
-
 		#[pallet::constant]
 		type MaxPropertiesPerTheme: Get<u32>;
 
@@ -153,8 +149,6 @@ pub mod pallet {
 		NeedsDefaultThemeFirst,
 		AlreadyEquipped,
 		UnknownError,
-		// no longer needed because we use PartsLimit in BoundedVec
-		// ExceedsMaxPartsPerBase,
 		TooManyProperties,
 	}
 

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -313,10 +313,6 @@ pub mod pallet {
 			let sender = ensure_signed(origin)?;
 
 			let part_length: u32 = parts.len().try_into().unwrap();
-
-			// We no longer need this because our bound is now on the BoundedVec of parts (PartsLimit)
-			// ensure!(part_length <= T::MaxPartsPerBase::get(), Error::<T>::ExceedsMaxPartsPerBase);
-
 			let base_id = Self::base_create(sender.clone(), base_type, symbol, parts)?;
 
 			Self::deposit_event(Event::BaseCreated { issuer: sender, base_id });

--- a/pallets/rmrk-equip/src/mock.rs
+++ b/pallets/rmrk-equip/src/mock.rs
@@ -43,6 +43,7 @@ parameter_types! {
 	// no longer needed as we use PartsLimit on the BoundedVec
 	// pub const MaxPartsPerBase: u32 = 5;
 	pub const MaxPropertiesPerTheme: u32 = 5;
+	pub const MaxCollectionsEquippablePerPart: u32 = 10;
 }
 
 impl pallet_rmrk_equip::Config for Test {
@@ -50,6 +51,7 @@ impl pallet_rmrk_equip::Config for Test {
 	// no longer needed as we use PartsLimit on the BoundedVec
 	// type MaxPartsPerBase = MaxPartsPerBase;
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
+	type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
 }
 
 parameter_types! {

--- a/pallets/rmrk-equip/src/mock.rs
+++ b/pallets/rmrk-equip/src/mock.rs
@@ -40,16 +40,12 @@ frame_support::construct_runtime!(
 );
 
 parameter_types! {
-	// no longer needed as we use PartsLimit on the BoundedVec
-	// pub const MaxPartsPerBase: u32 = 5;
 	pub const MaxPropertiesPerTheme: u32 = 5;
 	pub const MaxCollectionsEquippablePerPart: u32 = 10;
 }
 
 impl pallet_rmrk_equip::Config for Test {
 	type Event = Event;
-	// no longer needed as we use PartsLimit on the BoundedVec
-	// type MaxPartsPerBase = MaxPartsPerBase;
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
 	type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
 }

--- a/pallets/rmrk-equip/src/mock.rs
+++ b/pallets/rmrk-equip/src/mock.rs
@@ -55,6 +55,7 @@ parameter_types! {
 	pub MaxMetadataLength: u32 = 256;
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
+	pub const PartsLimit: u32 = 10;
 }
 
 impl pallet_rmrk_core::Config for Test {
@@ -63,6 +64,7 @@ impl pallet_rmrk_core::Config for Test {
 	type ProtocolOrigin = EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
 	type ResourceSymbolLimit = ResourceSymbolLimit;
+	type PartsLimit = PartsLimit;
 }
 
 parameter_types! {

--- a/pallets/rmrk-equip/src/mock.rs
+++ b/pallets/rmrk-equip/src/mock.rs
@@ -58,6 +58,7 @@ parameter_types! {
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
 	pub const PartsLimit: u32 = 10;
+	pub const MaxPriorities: u32 = 3;
 }
 
 impl pallet_rmrk_core::Config for Test {
@@ -67,6 +68,7 @@ impl pallet_rmrk_core::Config for Test {
 	type MaxRecursions = MaxRecursions;
 	type ResourceSymbolLimit = ResourceSymbolLimit;
 	type PartsLimit = PartsLimit;
+	type MaxPriorities = MaxPriorities;
 }
 
 parameter_types! {

--- a/pallets/rmrk-equip/src/mock.rs
+++ b/pallets/rmrk-equip/src/mock.rs
@@ -40,13 +40,15 @@ frame_support::construct_runtime!(
 );
 
 parameter_types! {
-	pub const MaxPartsPerBase: u32 = 5;
+	// no longer needed as we use PartsLimit on the BoundedVec
+	// pub const MaxPartsPerBase: u32 = 5;
 	pub const MaxPropertiesPerTheme: u32 = 5;
 }
 
 impl pallet_rmrk_equip::Config for Test {
 	type Event = Event;
-	type MaxPartsPerBase = MaxPartsPerBase;
+	// no longer needed as we use PartsLimit on the BoundedVec
+	// type MaxPartsPerBase = MaxPartsPerBase;
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
 }
 

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -40,7 +40,7 @@ fn create_base_works() {
 			id: 102,
 			z: 0,
 			src: stb("slot_part_src"),
-			equippable: EquippableList::Custom(vec![
+			equippable: EquippableList::Custom(bvec![
 				0, // Collection 0
 				1, // Collection 1
 			]),
@@ -113,7 +113,7 @@ fn equip_works() {
 			id: 201,
 			z: 0,
 			src: stb("left-hand"),
-			equippable: EquippableList::Custom(vec![
+			equippable: EquippableList::Custom(bvec![
 				0, // Collection 0
 				1, // Collection 1
 			]),
@@ -123,7 +123,7 @@ fn equip_works() {
 			id: 202,
 			z: 0,
 			src: stb("right-hand"),
-			equippable: EquippableList::Custom(vec![
+			equippable: EquippableList::Custom(bvec![
 				0, // Collection 2
 				1, // Collection 3
 			]),
@@ -401,7 +401,7 @@ fn equippable_works() {
 			id: 201,
 			z: 0,
 			src: stb("left-hand"),
-			equippable: EquippableList::Custom(vec![
+			equippable: EquippableList::Custom(bvec![
 				0, // Collection 0
 				1, // Collection 1
 			]),
@@ -411,7 +411,7 @@ fn equippable_works() {
 			id: 202,
 			z: 0,
 			src: stb("right-hand"),
-			equippable: EquippableList::Custom(vec![
+			equippable: EquippableList::Custom(bvec![
 				2, // Collection 2
 				3, // Collection 3
 			]),
@@ -434,7 +434,7 @@ fn equippable_works() {
 			Origin::signed(ALICE),
 			0,                                     // base ID
 			202,                                   // slot ID
-			EquippableList::Custom(vec![5, 6, 7]), // equippable collections
+			EquippableList::Custom(bvec![5, 6, 7]), // equippable collections
 		));
 
 		// Last event should be EquippablesUpdated
@@ -448,7 +448,7 @@ fn equippable_works() {
 			id: 202,
 			z: 0,
 			src: stb("right-hand"),
-			equippable: EquippableList::Custom(vec![5, 6, 7]),
+			equippable: EquippableList::Custom(bvec![5, 6, 7]),
 		};
 		assert_eq!(RmrkEquip::parts(0, 202).unwrap(), PartType::SlotPart(should_be));
 
@@ -458,7 +458,7 @@ fn equippable_works() {
 				Origin::signed(ALICE),
 				666,                                   // base ID
 				202,                                   // slot ID
-				EquippableList::Custom(vec![5, 6, 7]), // equippable collections
+				EquippableList::Custom(bvec![5, 6, 7]), // equippable collections
 			),
 			Error::<Test>::BaseDoesntExist
 		);
@@ -469,7 +469,7 @@ fn equippable_works() {
 				Origin::signed(ALICE),
 				0,                                     // base ID
 				200,                                   // slot ID
-				EquippableList::Custom(vec![5, 6, 7]), // equippable collections
+				EquippableList::Custom(bvec![5, 6, 7]), // equippable collections
 			),
 			Error::<Test>::PartDoesntExist
 		);
@@ -480,7 +480,7 @@ fn equippable_works() {
 				Origin::signed(ALICE),
 				0,                                           // base ID
 				101,                                         // slot ID
-				EquippableList::Custom(vec![5, 6, 7, 8, 9]), // equippable collections
+				EquippableList::Custom(bvec![5, 6, 7, 8, 9]), // equippable collections
 			),
 			Error::<Test>::NoEquippableOnFixedPart
 		);
@@ -491,7 +491,7 @@ fn equippable_works() {
 				Origin::signed(BOB),
 				0,                                     // base ID
 				201,                                   // slot ID
-				EquippableList::Custom(vec![3, 4, 5]), // equippable collections
+				EquippableList::Custom(bvec![3, 4, 5]), // equippable collections
 			),
 			Error::<Test>::PermissionError
 		);

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -50,40 +50,53 @@ fn create_base_works() {
 			Origin::signed(ALICE), // origin
 			bvec![0u8; 20],        // base_type
 			bvec![0u8; 20],        // symbol
-			vec![PartType::FixedPart(fixed_part), PartType::SlotPart(slot_part),],
+			bvec![PartType::FixedPart(fixed_part), PartType::SlotPart(slot_part),],
 		));
 
 		// println!("{:?}", RmrkEquip::bases(0).unwrap());
 	});
 }
 
-/// Base: Attempting to create a base with more the max parts fails
-#[test]
-fn exceeding_max_parts_per_base_fails() {
-	ExtBuilder::default().build().execute_with(|| {
-		let mut parts = Vec::<PartType<BoundedVec<u8, UniquesStringLimit>>>::new();
-		for i in 100..110 {
-			let fixed_part = FixedPart { id: i, z: 0, src: stb("fixed_part_src") };
-			parts.push(PartType::FixedPart(fixed_part));
-		}
+// no longer needed as we use PartsLimit on BoundedVec
+// Base: Attempting to create a base with more the max parts fails
+// #[test]
+// fn exceeding_max_parts_per_base_fails() {
+// 	ExtBuilder::default().build().execute_with(|| {
+// 		let mut parts: BoundedVec::<PartType<BoundedVec<u8, UniquesStringLimit>>, PartsLimit> = bvec![
+// 			PartType::FixedPart(FixedPart { id: 100, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 101, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 102, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 103, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 104, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 105, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 106, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 107, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 108, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 109, z: 0, src: stb("fixed_part_src") }),
+// 			PartType::FixedPart(FixedPart { id: 110, z: 0, src: stb("fixed_part_src") }),
+// 		];
+// 		// for i in 100..110 {
+// 		// 	let fixed_part = FixedPart { id: i, z: 0, src: stb("fixed_part_src") };
+// 		// 	parts.push(PartType::FixedPart(fixed_part).clone());
+// 		// }
 
-		assert_noop!(
-			RmrkEquip::create_base(
-				Origin::signed(ALICE), // origin
-				bvec![0u8; 20],        // base_type
-				bvec![0u8; 20],        // symbol
-				parts,
-			),
-			Error::<Test>::ExceedsMaxPartsPerBase,
-		);
-	});
-}
+// 		assert_noop!(
+// 			RmrkEquip::create_base(
+// 				Origin::signed(ALICE), // origin
+// 				bvec![0u8; 20],        // base_type
+// 				bvec![0u8; 20],        // symbol
+// 				parts,
+// 			),
+// 			Error::<Test>::ExceedsMaxPartsPerBase,
+// 		);
+// 	});
+// }
 
 #[test]
 #[should_panic]
 fn exceeding_parts_bound_panics() {
 	// PartsLimit bound is 10 per mock.rs, 11 should panic on unwrap
-	let partsBoundedVec: BoundedVec<PartId, PartsLimit> = bvec![1,2,3,4,5,6,7,8,9,10,11];
+	let parts_bounded_vec: BoundedVec<PartId, PartsLimit> = bvec![1,2,3,4,5,6,7,8,9,10,11,12];
 }
 
 /// Base: Basic equip tests
@@ -120,7 +133,7 @@ fn equip_works() {
 			Origin::signed(ALICE), // origin
 			stb("svg"),            // base_type
 			stb("KANPEOPLE"),      // symbol
-			vec![
+			bvec![
 				PartType::FixedPart(fixed_part_body_1),
 				PartType::FixedPart(fixed_part_body_2),
 				PartType::SlotPart(slot_part_left_hand),
@@ -408,7 +421,7 @@ fn equippable_works() {
 			Origin::signed(ALICE), // origin
 			stb("svg"),            // base_type
 			stb("KANPEOPLE"),      // symbol
-			vec![
+			bvec![
 				PartType::FixedPart(fixed_part_body_1),
 				PartType::FixedPart(fixed_part_body_2),
 				PartType::SlotPart(slot_part_left_hand),
@@ -533,7 +546,7 @@ fn theme_add_works() {
 			Origin::signed(ALICE), // origin
 			bvec![0u8; 20],        // base_type
 			bvec![0u8; 20],        // symbol
-			vec![],
+			bvec![],
 		));
 
 		// Add non-default theme to base (should fail w/o default)
@@ -610,7 +623,7 @@ fn theme_add_too_many_properties_fails() {
 			Origin::signed(ALICE), // origin
 			bvec![0u8; 20],        // base_type
 			bvec![0u8; 20],        // symbol
-			vec![],
+			bvec![],
 		));
 
 		// Define a default theme with too many properties (10)

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -79,6 +79,13 @@ fn exceeding_max_parts_per_base_fails() {
 	});
 }
 
+#[test]
+#[should_panic]
+fn exceeding_parts_bound_panics() {
+	// PartsLimit bound is 10 per mock.rs, 11 should panic on unwrap
+	let partsBoundedVec: BoundedVec<PartId, PartsLimit> = bvec![1,2,3,4,5,6,7,8,9,10,11];
+}
+
 /// Base: Basic equip tests
 #[test]
 fn equip_works() {
@@ -222,7 +229,7 @@ fn equip_works() {
 			None,                           // slot
 			None,                           // license
 			None,                           // thumb
-			Some(vec![
+			Some(bvec![
 				// parts
 				101, // ID of body-1 part
 				201, // ID of left-hand slot

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -57,46 +57,18 @@ fn create_base_works() {
 	});
 }
 
-// no longer needed as we use PartsLimit on BoundedVec
-// Base: Attempting to create a base with more the max parts fails
-// #[test]
-// fn exceeding_max_parts_per_base_fails() {
-// 	ExtBuilder::default().build().execute_with(|| {
-// 		let mut parts: BoundedVec::<PartType<BoundedVec<u8, UniquesStringLimit>>, PartsLimit> = bvec![
-// 			PartType::FixedPart(FixedPart { id: 100, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 101, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 102, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 103, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 104, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 105, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 106, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 107, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 108, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 109, z: 0, src: stb("fixed_part_src") }),
-// 			PartType::FixedPart(FixedPart { id: 110, z: 0, src: stb("fixed_part_src") }),
-// 		];
-// 		// for i in 100..110 {
-// 		// 	let fixed_part = FixedPart { id: i, z: 0, src: stb("fixed_part_src") };
-// 		// 	parts.push(PartType::FixedPart(fixed_part).clone());
-// 		// }
-
-// 		assert_noop!(
-// 			RmrkEquip::create_base(
-// 				Origin::signed(ALICE), // origin
-// 				bvec![0u8; 20],        // base_type
-// 				bvec![0u8; 20],        // symbol
-// 				parts,
-// 			),
-// 			Error::<Test>::ExceedsMaxPartsPerBase,
-// 		);
-// 	});
-// }
-
 #[test]
 #[should_panic]
 fn exceeding_parts_bound_panics() {
-	// PartsLimit bound is 10 per mock.rs, 11 should panic on unwrap
-	let parts_bounded_vec: BoundedVec<PartId, PartsLimit> = bvec![1,2,3,4,5,6,7,8,9,10,11,12];
+	// PartsLimit bound is 50 per mock.rs, 60 should panic on unwrap
+	let parts_bounded_vec: BoundedVec<PartId, PartsLimit> = bvec![
+		1,2,3,4,5,6,7,8,9,10,
+		1,2,3,4,5,6,7,8,9,10,
+		1,2,3,4,5,6,7,8,9,10,
+		1,2,3,4,5,6,7,8,9,10,
+		1,2,3,4,5,6,7,8,9,10,
+		1,2,3,4,5,6,7,8,9,10,
+		];
 }
 
 /// Base: Basic equip tests

--- a/pallets/rmrk-market/src/mock.rs
+++ b/pallets/rmrk-market/src/mock.rs
@@ -94,6 +94,7 @@ parameter_types! {
 	pub MaxMetadataLength: u32 = 256;
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
+	pub const PartsLimit: u32 = 10;
 }
 
 impl pallet_rmrk_core::Config for Test {
@@ -102,6 +103,7 @@ impl pallet_rmrk_core::Config for Test {
 	type ProtocolOrigin = EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
 	type ResourceSymbolLimit = ResourceSymbolLimit;
+	type PartsLimit = PartsLimit;
 }
 
 parameter_types! {

--- a/pallets/rmrk-market/src/mock.rs
+++ b/pallets/rmrk-market/src/mock.rs
@@ -95,6 +95,7 @@ parameter_types! {
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
 	pub const PartsLimit: u32 = 10;
+	pub const MaxPriorities: u32 = 3;
 }
 
 impl pallet_rmrk_core::Config for Test {
@@ -104,6 +105,7 @@ impl pallet_rmrk_core::Config for Test {
 	type MaxRecursions = MaxRecursions;
 	type ResourceSymbolLimit = ResourceSymbolLimit;
 	type PartsLimit = PartsLimit;
+	type MaxPriorities = MaxPriorities;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -340,16 +340,12 @@ parameter_types! {
 	pub const AttributeDepositBase: Balance = 10 * DOLLARS;
 	pub const DepositPerByte: Balance = DOLLARS;
 	pub const UniquesStringLimit: u32 = 128;
-	// no longer needed as we use PartsLimit on BoundedVec
-	// pub const MaxPartsPerBase: u32 = 100;
 	pub const MaxPropertiesPerTheme: u32 = 100;
 	pub const MaxCollectionsEquippablePerPart: u32 = 100;
 }
 
 impl pallet_rmrk_equip::Config for Runtime {
 	type Event = Event;
-	// no longer needed as we use PartsLimit on BoundedVec
-	// type MaxPartsPerBase = MaxPartsPerBase;
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
 	type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -305,13 +305,14 @@ impl pallet_template::Config for Runtime {
 parameter_types! {
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
+	pub const PartsLimit: u32 = 1000;
 }
 
 impl pallet_rmrk_core::Config for Runtime {
 	type Event = Event;
 	type ProtocolOrigin = frame_system::EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
-	type ResourceSymbolLimit = ResourceSymbolLimit;
+	type PartsLimit = PartsLimit;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -305,13 +305,14 @@ impl pallet_template::Config for Runtime {
 parameter_types! {
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
-	pub const PartsLimit: u32 = 1000;
+	pub const PartsLimit: u32 = 3;
 }
 
 impl pallet_rmrk_core::Config for Runtime {
 	type Event = Event;
 	type ProtocolOrigin = frame_system::EnsureRoot<AccountId>;
 	type MaxRecursions = MaxRecursions;
+	type ResourceSymbolLimit = ResourceSymbolLimit;
 	type PartsLimit = PartsLimit;
 }
 
@@ -335,13 +336,15 @@ parameter_types! {
 	pub const AttributeDepositBase: Balance = 10 * DOLLARS;
 	pub const DepositPerByte: Balance = DOLLARS;
 	pub const UniquesStringLimit: u32 = 128;
-	pub const MaxPartsPerBase: u32 = 100;
+	// no longer needed as we use PartsLimit on BoundedVec
+	// pub const MaxPartsPerBase: u32 = 100;
 	pub const MaxPropertiesPerTheme: u32 = 100;
 }
 
 impl pallet_rmrk_equip::Config for Runtime {
 	type Event = Event;
-	type MaxPartsPerBase = MaxPartsPerBase;
+	// no longer needed as we use PartsLimit on BoundedVec
+	// type MaxPartsPerBase = MaxPartsPerBase;
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -306,6 +306,7 @@ parameter_types! {
 	pub const MaxRecursions: u32 = 10;
 	pub const ResourceSymbolLimit: u32 = 10;
 	pub const PartsLimit: u32 = 3;
+	pub const MaxPriorities: u32 = 3;
 }
 
 impl pallet_rmrk_core::Config for Runtime {
@@ -314,6 +315,7 @@ impl pallet_rmrk_core::Config for Runtime {
 	type MaxRecursions = MaxRecursions;
 	type ResourceSymbolLimit = ResourceSymbolLimit;
 	type PartsLimit = PartsLimit;
+	type MaxPriorities = MaxPriorities;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -339,6 +339,7 @@ parameter_types! {
 	// no longer needed as we use PartsLimit on BoundedVec
 	// pub const MaxPartsPerBase: u32 = 100;
 	pub const MaxPropertiesPerTheme: u32 = 100;
+	pub const MaxCollectionsEquippablePerPart: u32 = 100;
 }
 
 impl pallet_rmrk_equip::Config for Runtime {
@@ -346,6 +347,7 @@ impl pallet_rmrk_equip::Config for Runtime {
 	// no longer needed as we use PartsLimit on BoundedVec
 	// type MaxPartsPerBase = MaxPartsPerBase;
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
+	type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
 }
 
 impl pallet_uniques::Config for Runtime {

--- a/traits/src/base.rs
+++ b/traits/src/base.rs
@@ -7,9 +7,11 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{DispatchError, RuntimeDebug};
 use sp_std::vec::Vec;
+use frame_support::pallet_prelude::MaxEncodedLen;
+
 
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct BaseInfo<AccountId, BoundedString, BoundedParts> {
 	/// Original creator of the Base
 	pub issuer: AccountId,
@@ -22,7 +24,7 @@ pub struct BaseInfo<AccountId, BoundedString, BoundedParts> {
 }
 
 // Abstraction over a Base system.
-pub trait Base<AccountId, CollectionId, NftId, BoundedString, BoundedParts> {
+pub trait Base<AccountId, CollectionId, NftId, BoundedString, BoundedParts, BoundedCollectionList> {
 	fn base_create(
 		issuer: AccountId,
 		base_type: BoundedString,
@@ -40,7 +42,7 @@ pub trait Base<AccountId, CollectionId, NftId, BoundedString, BoundedParts> {
 		issuer: AccountId,
 		base_id: BaseId,
 		slot: SlotId,
-		equippables: EquippableList,
+		equippables: EquippableList<BoundedCollectionList>,
 	) -> Result<(BaseId, SlotId), DispatchError>;
 	fn add_theme(
 		issuer: AccountId,

--- a/traits/src/base.rs
+++ b/traits/src/base.rs
@@ -10,7 +10,7 @@ use sp_std::vec::Vec;
 
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
 #[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
-pub struct BaseInfo<AccountId, BoundedString> {
+pub struct BaseInfo<AccountId, BoundedString, BoundedParts> {
 	/// Original creator of the Base
 	pub issuer: AccountId,
 	/// Specifies how an NFT should be rendered, ie "svg"
@@ -18,16 +18,16 @@ pub struct BaseInfo<AccountId, BoundedString> {
 	/// User provided symbol during Base creation
 	pub symbol: BoundedString,
 	/// Parts, full list of both Fixed and Slot parts
-	pub parts: Vec<PartType<BoundedString>>,
+	pub parts: BoundedParts,
 }
 
 // Abstraction over a Base system.
-pub trait Base<AccountId, CollectionId, NftId, BoundedString> {
+pub trait Base<AccountId, CollectionId, NftId, BoundedString, BoundedParts> {
 	fn base_create(
 		issuer: AccountId,
 		base_type: BoundedString,
 		symbol: BoundedString,
-		parts: Vec<PartType<BoundedString>>,
+		parts: BoundedParts,
 	) -> Result<BaseId, DispatchError>;
 	fn do_equip(
 		issuer: AccountId, // Maybe don't need?

--- a/traits/src/collection.rs
+++ b/traits/src/collection.rs
@@ -8,8 +8,6 @@ use sp_std::result::Result;
 
 /// Collection info.
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
-// #[derive(Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
-// pub struct CollectionInfo<BoundedString, AccountId> {
 #[derive(Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct CollectionInfo<BoundedString, BoundedSymbol, AccountId> {
 	/// Current bidder and bid price.

--- a/traits/src/collection.rs
+++ b/traits/src/collection.rs
@@ -1,13 +1,14 @@
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{DispatchError, DispatchResult, RuntimeDebug};
+use frame_support::pallet_prelude::MaxEncodedLen;
 
 use crate::primitives::*;
 use sp_std::result::Result;
 
 /// Collection info.
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct CollectionInfo<BoundedString, AccountId> {
 	/// Current bidder and bid price.
 	pub issuer: AccountId,

--- a/traits/src/nft.rs
+++ b/traits/src/nft.rs
@@ -12,7 +12,7 @@ use sp_std::result::Result;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum AccountIdOrCollectionNftTuple<AccountId> {
 	AccountId(AccountId),
@@ -21,7 +21,7 @@ pub enum AccountIdOrCollectionNftTuple<AccountId> {
 
 /// Nft info.
 #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct NftInfo<AccountId, BoundedString> {
 	/// The owner of the NFT, can be either an Account or a tuple (CollectionId, NftId)
 	pub owner: AccountIdOrCollectionNftTuple<AccountId>,

--- a/traits/src/part.rs
+++ b/traits/src/part.rs
@@ -3,34 +3,36 @@ use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 use sp_std::vec::Vec;
+use frame_support::pallet_prelude::MaxEncodedLen;
 
 // #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq)]
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
 pub struct FixedPart<BoundedString> {
 	pub id: PartId,
 	pub z: ZIndex,
 	pub src: BoundedString,
 }
 
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq)]
-pub enum EquippableList {
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
+pub enum EquippableList<BoundedCollectionList> {
 	All,
 	Empty,
-	Custom(Vec<CollectionId>),
+	Custom(BoundedCollectionList),
+	// Custom(Vec<CollectionId>),
 }
 
 // #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq)]
-pub struct SlotPart<BoundedString> {
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
+pub struct SlotPart<BoundedString, BoundedCollectionList> {
 	pub id: PartId,
-	pub equippable: EquippableList,
+	pub equippable: EquippableList<BoundedCollectionList>,
 	pub src: BoundedString,
 	pub z: ZIndex,
 }
 
 // #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
-#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq)]
-pub enum PartType<BoundedString> {
+#[derive(Encode, Decode, RuntimeDebug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
+pub enum PartType<BoundedString, BoundedCollectionList> {
 	FixedPart(FixedPart<BoundedString>),
-	SlotPart(SlotPart<BoundedString>),
+	SlotPart(SlotPart<BoundedString, BoundedCollectionList>),
 }

--- a/traits/src/priority.rs
+++ b/traits/src/priority.rs
@@ -5,11 +5,11 @@ use sp_std::vec::Vec;
 
 /// Abstraction over a Priority system.
 #[allow(clippy::upper_case_acronyms)]
-pub trait Priority<BoundedString, AccountId> {
+pub trait Priority<BoundedString, AccountId, BoundedPriorities> {
 	fn priority_set(
 		sender: AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
-		priorities: Vec<Vec<u8>>,
+		priorities: BoundedPriorities,
 	) -> DispatchResult;
 }

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -5,11 +5,12 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_runtime::{DispatchError, DispatchResult, RuntimeDebug};
 use sp_std::{cmp::Eq, vec::Vec};
+use frame_support::pallet_prelude::MaxEncodedLen;
 
 use crate::primitives::*;
 
 
-#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo)]
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct ResourceInfo<BoundedResource, BoundedString, BoundedParts> {
 	/// id is a 5-character string of reasonable uniqueness.

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -11,7 +11,7 @@ use crate::primitives::*;
 
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ResourceInfo<BoundedResource, BoundedString> {
+pub struct ResourceInfo<BoundedResource, BoundedString, BoundedParts> {
 	/// id is a 5-character string of reasonable uniqueness.
 	/// The combination of base ID and resource id should be unique across the entire RMRK
 	/// ecosystem which
@@ -21,7 +21,7 @@ pub struct ResourceInfo<BoundedResource, BoundedString> {
 	pub pending: bool,
 
 	/// If a resource is composed, it will have an array of parts that compose it
-	pub parts: Option<Vec<PartId>>,
+	pub parts: Option<BoundedParts>,
 
 	/// A Base is uniquely identified by the combination of the word `base`, its minting block
 	/// number, and user provided symbol during Base creation, glued by dashes `-`, e.g.
@@ -49,7 +49,7 @@ pub struct ResourceInfo<BoundedResource, BoundedString> {
 }
 
 /// Abstraction over a Resource system.
-pub trait Resource<BoundedString, AccountId, BoundedResource> {
+pub trait Resource<BoundedString, AccountId, BoundedResource, BoundedPart> {
 	fn resource_add(
 		sender: AccountId,
 		collection_id: CollectionId,
@@ -61,7 +61,7 @@ pub trait Resource<BoundedString, AccountId, BoundedResource> {
 		slot: Option<SlotId>,
 		license: Option<BoundedString>,
 		thumb: Option<BoundedString>,
-		parts: Option<Vec<PartId>>,
+		parts: Option<BoundedPart>,
 	) -> DispatchResult;
 	fn accept(
 		sender: AccountId,


### PR DESCRIPTION
addresses #93.  We may be able to alias some of the generics to make it a bit more readable, but this should pass tests for all of equip, market and core, and should successfully remove #[pallet::without_storage_info]