### PR TITLE
implement ResourceNotPending when accepting a resource that need not be accepted

### DIFF
--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -250,6 +250,8 @@ pub mod pallet {
 		CannotAcceptNonOwnedNft,
 		CannotRejectNonOwnedNft,
 		ResourceDoesntExist,
+		/// Accepting a resource that is not pending should fail
+		ResourceNotPending,
 	}
 
 	#[pallet::call]
@@ -588,6 +590,7 @@ pub mod pallet {
 				(collection_id, nft_id, resource_id.clone()),
 				|resource| -> DispatchResult {
 					if let Some(res) = resource.into_mut() {
+						ensure!(res.pending, Error::<T>::ResourceNotPending);
 						res.pending = false;
 					}
 					Ok(())

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -805,6 +805,8 @@ fn add_resource_pending_works() {
 		}));
 		// Resource should now have false pending status
 		assert_eq!(RMRKCore::resources((0, 0, stbr("res-4"))).unwrap().pending, false);
+		// Accepting resource again should fail with ResourceNotPending
+		assert_noop!(RMRKCore::accept_resource(Origin::signed(ALICE), 0, 0, stbr("res-4")), Error::<Test>::ResourceNotPending);
 	});
 }
 


### PR DESCRIPTION
fixes #55 where we don't checking pending state on a resource before allowing it to be accepted (which is redundant but success would trigger accept events which it shouldn't)