### PR TITLE
Bug/120 split resource into composable slot basic

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -74,24 +74,30 @@ where
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource_id: BoundedResource<T::ResourceSymbolLimit>,
-		base: Option<BaseId>,
-		src: Option<BoundedVec<u8, T::StringLimit>>,
-		metadata: Option<BoundedVec<u8, T::StringLimit>>,
-		slot: Option<SlotId>,
-		license: Option<BoundedVec<u8, T::StringLimit>>,
-		thumb: Option<BoundedVec<u8, T::StringLimit>>,
-		parts: Option<BoundedVec<PartId, T::PartsLimit>>,
+		resource: ResourceTypes<BoundedVec<u8, T::StringLimit>, BoundedVec<PartId, T::PartsLimit>>,
+		// base: Option<BaseId>,
+		// src: Option<BoundedVec<u8, T::StringLimit>>,
+		// metadata: Option<BoundedVec<u8, T::StringLimit>>,
+		// slot: Option<SlotId>,
+		// license: Option<BoundedVec<u8, T::StringLimit>>,
+		// thumb: Option<BoundedVec<u8, T::StringLimit>>,
+		// parts: Option<BoundedVec<PartId, T::PartsLimit>>,
 	) -> DispatchResult {
 		let collection = Self::collections(collection_id).ok_or(Error::<T>::CollectionUnknown)?;
 		ensure!(collection.issuer == sender, Error::<T>::NoPermission);
 		let (root_owner, _) = Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
 
-		let empty =
-			base.is_none() &&
-				src.is_none() && metadata.is_none() &&
-				slot.is_none() && license.is_none() &&
-				thumb.is_none();
-		ensure!(!empty, Error::<T>::EmptyResource);
+		// match resource {
+		// 	ResourceTypes::Basic(res) => {
+				
+		// 	},
+		// 	ResourceTypes::Composable(res) => {
+				
+		// 	},
+		// 	ResourceTypes::Slot(res) => {
+				
+		// 	}
+		// }
 
 		let res = ResourceInfo::<
 			BoundedVec<u8, T::ResourceSymbolLimit>,
@@ -99,15 +105,16 @@ where
 			BoundedVec<PartId, T::PartsLimit>,
 		> {
 			id: resource_id.clone(),
-			base,
-			src,
-			metadata,
-			slot,
-			license,
-			thumb,
-			parts,
+			// base,
+			// src,
+			// metadata,
+			// slot,
+			// license,
+			// thumb,
+			// parts,
 			pending: root_owner != sender,
 			pending_removal: false,
+			resource
 		};
 		Resources::<T>::insert((collection_id, nft_id, resource_id), res);
 

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -12,7 +12,8 @@ use sp_std::convert::TryInto;
 
 use rmrk_traits::{
 	primitives::*, AccountIdOrCollectionNftTuple, Collection, CollectionInfo, Nft, NftInfo,
-	Priority, Property, Resource, ResourceInfo, RoyaltyInfo
+	Priority, Property, Resource, ResourceInfo, RoyaltyInfo,
+	ResourceTypes, BasicResource, SlotResource, ComposableResource
 };
 use sp_std::result::Result;
 
@@ -562,21 +563,15 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Create resource
+		/// Create basic resource
 		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
 		#[transactional]
-		pub fn add_resource(
+		pub fn add_basic_resource(
 			origin: OriginFor<T>,
 			collection_id: CollectionId,
 			nft_id: NftId,
 			resource_id: BoundedResource<T::ResourceSymbolLimit>,
-			base: Option<BaseId>,
-			src: Option<BoundedVec<u8, T::StringLimit>>,
-			metadata: Option<BoundedVec<u8, T::StringLimit>>,
-			slot: Option<SlotId>,
-			license: Option<BoundedVec<u8, T::StringLimit>>,
-			thumb: Option<BoundedVec<u8, T::StringLimit>>,
-			parts: Option<BoundedVec<PartId, T::PartsLimit>>,
+			resource: BasicResource<StringLimitOf<T>>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
 
@@ -585,13 +580,55 @@ pub mod pallet {
 				collection_id,
 				nft_id,
 				resource_id.clone(),
-				base,
-				src,
-				metadata,
-				slot,
-				license,
-				thumb,
-				parts,
+				ResourceTypes::Basic(resource),
+			)?;
+
+			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
+			Ok(())
+		}
+
+		/// Create composable resource
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn add_composable_resource(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			nft_id: NftId,
+			resource_id: BoundedResource<T::ResourceSymbolLimit>,
+			resource: ComposableResource<StringLimitOf<T>, BoundedVec<PartId, T::PartsLimit>>,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin.clone())?;
+
+			Self::resource_add(
+				sender,
+				collection_id,
+				nft_id,
+				resource_id.clone(),
+				ResourceTypes::Composable(resource),
+			)?;
+
+			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
+			Ok(())
+		}
+
+		/// Create slot resource
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn add_slot_resource(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			nft_id: NftId,
+			resource_id: BoundedResource<T::ResourceSymbolLimit>,
+			resource: SlotResource<StringLimitOf<T>>,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin.clone())?;
+
+			Self::resource_add(
+				sender,
+				collection_id,
+				nft_id,
+				resource_id.clone(),
+				ResourceTypes::Slot(resource),
 			)?;
 
 			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -636,32 +636,27 @@ fn burn_nft_works() {
 		assert_ok!(basic_mint());
 		// Add two resources to NFT (to test if burning also burns the resources)
 
-		assert_ok!(RMRKCore::add_resource(
+		let basic_resource = BasicResource {
+			src: None,
+			metadata: None,
+			license: None,
+			thumb: None,
+		};
+
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			0,
 			0,
 			stbr("res-1"),
-			Some(0),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			None,
-			None,
-			None,
-			None
+			basic_resource.clone(),
 		));
 
-		assert_ok!(RMRKCore::add_resource(
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			0,
 			0,
 			stbr("res-2"),
-			Some(0),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			None,
-			None,
-			None,
-			None
+			basic_resource,
 		));
 
 		// Ensure resources are there
@@ -703,33 +698,29 @@ fn burn_nft_with_great_grandchildren_works() {
 		for _ in 0..4 {
 			assert_ok!(basic_mint());
 		}
+
+		let basic_resource = BasicResource {
+			src: None,
+			metadata: None,
+			license: None,
+			thumb: None,
+		};
+		
 		// Add two resources to the great-grandchild (0, 3)
-		assert_ok!(RMRKCore::add_resource(
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			3,
 			stbr("res-1"),
-			Some(0),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			None,
-			None,
-			None,
-			None
+			basic_resource.clone(),
 		));
 
-		assert_ok!(RMRKCore::add_resource(
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			3,
 			stbr("res-2"),
-			Some(0),
-			Some(bvec![0u8; 20]),
-			Some(bvec![0u8; 20]),
-			None,
-			None,
-			None,
-			None
+			basic_resource,
 		));
 
 		// Ensure resources are there
@@ -826,20 +817,21 @@ fn burn_nft_beyond_max_recursions_fails_gracefully() {
 #[test]
 fn create_resource_works() {
 	ExtBuilder::default().build().execute_with(|| {
+		let basic_resource = BasicResource {
+			src: None,
+			metadata: None,
+			license: None,
+			thumb: None,
+		};
+
 		// Adding a resource to non-existent NFT should fail
 		assert_noop!(
-			RMRKCore::add_resource(
+			RMRKCore::add_basic_resource(
 				Origin::signed(ALICE),
 				0,             // collection_id
 				0,             // nft_id
 				stbr("res-1"), // resource_id
-				Some(0),       // base_id
-				None,          // src
-				None,          // metadata
-				None,          // slot
-				None,          // license
-				None,          // thumb
-				None,          // parts
+				basic_resource,
 			),
 			Error::<Test>::CollectionUnknown
 		);
@@ -847,36 +839,21 @@ fn create_resource_works() {
 		assert_ok!(basic_collection());
 		// Mint NFT
 		assert_ok!(basic_mint());
-		// Adding an empty resource should fail
-		assert_noop!(
-			RMRKCore::add_resource(
-				Origin::signed(ALICE),
-				COLLECTION_ID_0,
-				NFT_ID_0,
-				stbr("res-2"), // resource_id
-				None,          // base_id
-				None,          // src
-				None,          // metadata
-				None,          // slot
-				None,          // license
-				None,          // thumb
-				None,          // parts
-			),
-			Error::<Test>::EmptyResource
-		);
+
+		let basic_resource = BasicResource {
+			src: None,
+			metadata: None,
+			license: None,
+			thumb: None,
+		};
+
 		// Add resource to NFT
-		assert_ok!(RMRKCore::add_resource(
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
 			stbr("res-3"), // resource_id
-			Some(0),       // base_id
-			None,          // src
-			None,          // metadata
-			None,          // slot
-			None,          // license
-			None,          // thumb
-			None,          // parts
+			basic_resource,
 		));
 		// Successful resource addition should trigger ResourceAdded event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAdded {
@@ -885,6 +862,9 @@ fn create_resource_works() {
 		}));
 		// Since ALICE rootowns NFT, pending status of resource should be false
 		assert_eq!(RMRKCore::resources((0, 0, stbr("res-3"))).unwrap().pending, false);
+
+		// TODO add composable resource works
+		// TODO add slot resource works
 	});
 }
 
@@ -903,37 +883,35 @@ fn add_resource_pending_works() {
 			Some(Permill::from_float(1.525)),
 			bvec![0u8; 20],
 		));
+
+		let basic_resource = BasicResource {
+			src: None,
+			metadata: None,
+			license: None,
+			thumb: None,
+		};
+
 		// Since BOB isn't collection issuer, he can't add resources
 		assert_noop!(
-			RMRKCore::add_resource(
+			RMRKCore::add_basic_resource(
 				Origin::signed(BOB),
 				COLLECTION_ID_0,
 				NFT_ID_0,
 				stbr("res-4"), // resource_id
-				Some(0),       // base_id
-				None,          // src
-				None,          // metadata
-				None,          // slot
-				None,          // license
-				None,          // thumb
-				None,          // parts
+				basic_resource.clone(),
 			),
 			Error::<Test>::NoPermission
 		);
+
 		// Collection issuer can add resource
-		assert_ok!(RMRKCore::add_resource(
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
 			stbr("res-4"), // resource_id
-			Some(0),       // base_id
-			None,          // src
-			None,          // metadata
-			None,          // slot
-			None,          // license
-			None,          // thumb
-			None,          // parts
+			basic_resource
 		));
+
 		assert_eq!(RMRKCore::resources((0, 0, stbr("res-4"))).unwrap().pending, true);
 		// ALICE doesn't own BOB's NFT, so accept should fail
 		assert_noop!(
@@ -965,19 +943,21 @@ fn resource_removal_works() {
 		assert_ok!(basic_collection());
 		// Mint NFT
 		assert_ok!(basic_mint());
+
+		let basic_resource = BasicResource {
+			src: None,
+			metadata: None,
+			license: None,
+			thumb: None,
+		};
+
 		// Add resource to NFT
-		assert_ok!(RMRKCore::add_resource(
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
 			stbr("res-0"), // resource_id
-			Some(0),       // base_id
-			None,          // src
-			None,          // metadata
-			None,          // slot
-			None,          // license
-			None,          // thumb
-			None,          // parts
+			basic_resource,
 		));
 		// Resource res-1 doesn't exist
 		assert_noop!(
@@ -1031,20 +1011,23 @@ fn resource_removal_pending_works() {
 			Some(Permill::from_float(1.525)),
 			bvec![0u8; 20],
 		));
+
+		let basic_resource = BasicResource {
+			src: None,
+			metadata: None,
+			license: None,
+			thumb: None,
+		};
+
 		// Add resource to NFT
-		assert_ok!(RMRKCore::add_resource(
+		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
 			stbr("res-0"), // resource_id
-			Some(0),       // base_id
-			None,          // src
-			None,          // metadata
-			None,          // slot
-			None,          // license
-			None,          // thumb
-			None,          // parts
+			basic_resource,
 		));
+
 		assert_ok!(RMRKCore::accept_resource(
 			Origin::signed(BOB),
 			COLLECTION_ID_0,

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -25,6 +25,11 @@ fn stbk(s: &str) -> BoundedVec<u8, KeyLimit> {
 	s.as_bytes().to_vec().try_into().unwrap()
 }
 
+/// Turns a string into a BoundedVec
+fn stbd(s: &str) -> StringLimitOf<Test> {
+	s.as_bytes().to_vec().try_into().unwrap()
+}
+
 /// Turns a string into a Vec
 fn stv(s: &str) -> Vec<u8> {
 	s.as_bytes().to_vec()
@@ -863,8 +868,43 @@ fn create_resource_works() {
 		// Since ALICE rootowns NFT, pending status of resource should be false
 		assert_eq!(RMRKCore::resources((0, 0, stbr("res-3"))).unwrap().pending, false);
 
-		// TODO add composable resource works
-		// TODO add slot resource works
+		// Create Composable resource
+		let composable_resource = ComposableResource {
+			parts: vec![0, 1].try_into().unwrap(), // BoundedVec of Parts
+			src: Some(stbd("composable-resource")),
+			base: 0, // BaseID
+			license: None,
+			metadata: None,
+			thumb: None,
+		};
+
+		// Composable resource addition works
+		assert_ok!(RMRKCore::add_composable_resource(
+			Origin::signed(ALICE),
+			COLLECTION_ID_0,
+			NFT_ID_0,
+			stbr("res-3"), // resource_id
+			composable_resource,
+		));
+		
+		// Create Slot resource
+		let slot_resource = SlotResource {
+			src: Some(stbd("slot-resource")),
+			base: 0, // BaseID
+			license: None,
+			metadata: None,
+			slot: 0, // SlotID
+			thumb: None,
+		};
+
+		// Slot resource addition works
+		assert_ok!(RMRKCore::add_slot_resource(
+			Origin::signed(ALICE),
+			COLLECTION_ID_0,
+			NFT_ID_0,
+			stbr("res-3"), // resource_id
+			slot_resource,
+		));
 	});
 }
 
@@ -885,7 +925,7 @@ fn add_resource_pending_works() {
 		));
 
 		let basic_resource = BasicResource {
-			src: None,
+			src: Some(stbd("res-src")),
 			metadata: None,
 			license: None,
 			thumb: None,

--- a/pallets/rmrk-equip/src/functions.rs
+++ b/pallets/rmrk-equip/src/functions.rs
@@ -219,10 +219,17 @@ where
 			equipper_collection_id,
 			equipper_nft_id,
 		));
+
 		for resource in resources_matching_base_iter {
-			if resource.base.is_some() && resource.base.unwrap() == base_id {
-				found_base_resource_on_nft = true;
+			match resource.resource {
+				ResourceTypes::Composable(res) => {
+					if res.base == base_id {
+						found_base_resource_on_nft = true;
+					}
+				},
+				_ => (),
 			}
+			
 		}
 
 		// If we don't find a matching base resource, we raise a NoResourceForThisBaseFoundOnNft
@@ -231,20 +238,23 @@ where
 
 		// The item being equipped must be have a resource that is equippable into that base.slot
 		let mut found_base_slot_resource_on_nft = false;
+
 		// initialized so the compiler doesn't complain, though it will be overwritten if it
 		// resource exists
 		let mut to_equip_resource_id: BoundedResource<T> = b"".to_vec().try_into().unwrap();
+
 		let resources_matching_base_iter =
 			pallet_rmrk_core::Resources::<T>::iter_prefix_values((item_collection_id, item_nft_id));
 
 		for resource in resources_matching_base_iter {
-			if resource.base.is_some() &&
-				resource.slot.is_some() &&
-				resource.base.unwrap() == base_id &&
-				resource.slot.unwrap() == slot_id
-			{
-				found_base_slot_resource_on_nft = true;
-				to_equip_resource_id = resource.id;
+			match resource.resource {
+				ResourceTypes::Slot(res) => {
+					if res.slot == slot_id && res.base == base_id {
+						found_base_slot_resource_on_nft = true;
+						to_equip_resource_id = resource.id;
+					}
+				},
+				_ => (),
 			}
 		}
 		ensure!(found_base_slot_resource_on_nft, Error::<T>::ItemHasNoResourceToEquipThere);

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -12,6 +12,7 @@ pub use pallet::*;
 
 use rmrk_traits::{
 	primitives::*, AccountIdOrCollectionNftTuple, Base, BaseInfo, EquippableList, PartType, Theme,
+	BasicResource, ComposableResource, SlotResource, ResourceTypes,
 };
 
 mod functions;

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -17,7 +17,7 @@ pub use collection::{Collection, CollectionInfo};
 pub use nft::{AccountIdOrCollectionNftTuple, Nft, NftInfo, RoyaltyInfo};
 pub use priority::Priority;
 pub use property::Property;
-pub use resource::{Resource, ResourceInfo};
+pub use resource::{Resource, ResourceInfo, ResourceTypes, BasicResource, SlotResource, ComposableResource};
 pub mod primitives {
 	pub type CollectionId = u32;
 	pub type ResourceId = u32;

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -35,12 +35,12 @@ pub struct BasicResource<BoundedString> {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct ComposableResource<BoundedString, BoundedParts> {
 	/// If a resource is composed, it will have an array of parts that compose it
-	pub parts: Option<BoundedParts>,
+	pub parts: BoundedParts,
 
 	/// A Base is uniquely identified by the combination of the word `base`, its minting block
 	/// number, and user provided symbol during Base creation, glued by dashes `-`, e.g.
 	/// base-4477293-kanaria_superbird.
-	pub base: Option<BaseId>,
+	pub base: BaseId,
 
 	/// If the resource is Media, the base property is absent. Media src should be a URI like an
 	/// IPFS hash.

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -9,40 +9,19 @@ use frame_support::pallet_prelude::MaxEncodedLen;
 
 use crate::primitives::*;
 
-
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ResourceInfo<BoundedResource, BoundedString, BoundedParts> {
-	/// id is a 5-character string of reasonable uniqueness.
-	/// The combination of base ID and resource id should be unique across the entire RMRK
-	/// ecosystem which
-	pub id: BoundedResource,
-
-	/// If resource is sent to non-rootowned NFT, pending will be false and need to be accepted
-	pub pending: bool,
-
-	/// If resource removal request is sent by non-rootowned NFT, pending will be true and need to be accepted
-	pub pending_removal: bool,
-
-	/// If a resource is composed, it will have an array of parts that compose it
-	pub parts: Option<BoundedParts>,
-
-	/// A Base is uniquely identified by the combination of the word `base`, its minting block
-	/// number, and user provided symbol during Base creation, glued by dashes `-`, e.g.
-	/// base-4477293-kanaria_superbird.
-	pub base: Option<BaseId>,
+pub struct BasicResource<BoundedString> {
 	/// If the resource is Media, the base property is absent. Media src should be a URI like an
 	/// IPFS hash.
 	pub src: Option<BoundedString>,
+
+	/// Reference to IPFS location of metadata
 	pub metadata: Option<BoundedString>,
-	/// If the resource has the slot property, it was designed to fit into a specific Base's slot.
-	/// The baseslot will be composed of two dot-delimited values, like so:
-	/// "base-4477293-kanaria_superbird.machine_gun_scope". This means: "This resource is
-	/// compatible with the machine_gun_scope slot of base base-4477293-kanaria_superbird
-	pub slot: Option<SlotId>,
-	/// The license field, if present, should contain a link to a license (IPFS or static HTTP
-	/// url), or an identifier, like RMRK_nocopy or ipfs://ipfs/someHashOfLicense.
+
+	/// Optional location or identier of license
 	pub license: Option<BoundedString>,
+
 	/// If the resource has the thumb property, this will be a URI to a thumbnail of the given
 	/// resource. For example, if we have a composable NFT like a Kanaria bird, the resource is
 	/// complex and too detailed to show in a search-results page or a list. Also, if a bird owns
@@ -52,6 +31,102 @@ pub struct ResourceInfo<BoundedResource, BoundedString, BoundedParts> {
 	pub thumb: Option<BoundedString>,
 }
 
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct ComposableResource<BoundedString, BoundedParts> {
+	/// If a resource is composed, it will have an array of parts that compose it
+	pub parts: Option<BoundedParts>,
+
+	/// A Base is uniquely identified by the combination of the word `base`, its minting block
+	/// number, and user provided symbol during Base creation, glued by dashes `-`, e.g.
+	/// base-4477293-kanaria_superbird.
+	pub base: Option<BaseId>,
+
+	/// If the resource is Media, the base property is absent. Media src should be a URI like an
+	/// IPFS hash.
+	pub src: Option<BoundedString>,
+
+	/// Reference to IPFS location of metadata
+	pub metadata: Option<BoundedString>,
+
+	/// If the resource has the slot property, it was designed to fit into a specific Base's slot.
+	/// The baseslot will be composed of two dot-delimited values, like so:
+	/// "base-4477293-kanaria_superbird.machine_gun_scope". This means: "This resource is
+	/// compatible with the machine_gun_scope slot of base base-4477293-kanaria_superbird
+
+	/// Optional location or identier of license
+	pub license: Option<BoundedString>,
+
+	/// If the resource has the thumb property, this will be a URI to a thumbnail of the given
+	/// resource. For example, if we have a composable NFT like a Kanaria bird, the resource is
+	/// complex and too detailed to show in a search-results page or a list. Also, if a bird owns
+	/// another bird, showing the full render of one bird inside the other's inventory might be a
+	/// bit of a strain on the browser. For this reason, the thumb value can contain a URI to an
+	/// image that is lighter and faster to load but representative of this resource.
+	pub thumb: Option<BoundedString>,
+}
+
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct SlotResource<BoundedString> {
+	/// A Base is uniquely identified by the combination of the word `base`, its minting block
+	/// number, and user provided symbol during Base creation, glued by dashes `-`, e.g.
+	/// base-4477293-kanaria_superbird.
+	pub base: BaseId,
+
+	/// If the resource is Media, the base property is absent. Media src should be a URI like an
+	/// IPFS hash.
+	pub src: Option<BoundedString>,
+
+	/// Reference to IPFS location of metadata
+	pub metadata: Option<BoundedString>,
+
+	/// If the resource has the slot property, it was designed to fit into a specific Base's slot.
+	/// The baseslot will be composed of two dot-delimited values, like so:
+	/// "base-4477293-kanaria_superbird.machine_gun_scope". This means: "This resource is
+	/// compatible with the machine_gun_scope slot of base base-4477293-kanaria_superbird
+	pub slot: SlotId,
+
+	/// The license field, if present, should contain a link to a license (IPFS or static HTTP
+	/// url), or an identifier, like RMRK_nocopy or ipfs://ipfs/someHashOfLicense.
+	pub license: Option<BoundedString>,
+
+	/// If the resource has the thumb property, this will be a URI to a thumbnail of the given
+	/// resource. For example, if we have a composable NFT like a Kanaria bird, the resource is
+	/// complex and too detailed to show in a search-results page or a list. Also, if a bird owns
+	/// another bird, showing the full render of one bird inside the other's inventory might be a
+	/// bit of a strain on the browser. For this reason, the thumb value can contain a URI to an
+	/// image that is lighter and faster to load but representative of this resource.
+	pub thumb: Option<BoundedString>,
+}
+
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum ResourceTypes<BoundedString, BoundedParts> {
+	Basic(BasicResource<BoundedString>),
+	Composable(ComposableResource<BoundedString, BoundedParts>),
+	Slot(SlotResource<BoundedString>),
+}
+
+
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct ResourceInfo<BoundedResource, BoundedString, BoundedParts> {
+	/// id is a 5-character string of reasonable uniqueness.
+	/// The combination of base ID and resource id should be unique across the entire RMRK
+	/// ecosystem which
+	pub id: BoundedResource,
+	
+	/// Resource
+	pub resource: ResourceTypes<BoundedString, BoundedParts>,
+
+	/// If resource is sent to non-rootowned NFT, pending will be false and need to be accepted
+	pub pending: bool,
+
+	/// If resource removal request is sent by non-rootowned NFT, pending will be true and need to be accepted
+	pub pending_removal: bool,
+}
+
 /// Abstraction over a Resource system.
 pub trait Resource<BoundedString, AccountId, BoundedResource, BoundedPart> {
 	fn resource_add(
@@ -59,13 +134,14 @@ pub trait Resource<BoundedString, AccountId, BoundedResource, BoundedPart> {
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource_id: BoundedResource,
-		base: Option<BaseId>,
-		src: Option<BoundedString>,
-		metadata: Option<BoundedString>,
-		slot: Option<SlotId>,
-		license: Option<BoundedString>,
-		thumb: Option<BoundedString>,
-		parts: Option<BoundedPart>,
+		resource: ResourceTypes<BoundedString, BoundedPart>,
+		// base: Option<BaseId>,
+		// src: Option<BoundedString>,
+		// metadata: Option<BoundedString>,
+		// slot: Option<SlotId>,
+		// license: Option<BoundedString>,
+		// thumb: Option<BoundedString>,
+		// parts: Option<BoundedPart>,
 	) -> DispatchResult;
 	fn accept(
 		sender: AccountId,


### PR DESCRIPTION
Addresses #120

Splits `add_resource` into `add_basic_resource`, `add_composable_resource`, and `add_slot_resource`.  This should clean up the need for Options, and maintain a bit more logic and organization.

`add_basic_resource`:
![image](https://user-images.githubusercontent.com/13931806/166942005-52d247ab-ff7f-4d03-ba81-5b3a6cbcbf09.png)

`add_composable_resource`:
![image](https://user-images.githubusercontent.com/13931806/166942085-c345f0a1-3c10-49a3-a804-5fc68a8da0e1.png)

`add_slot_resource`:
![image](https://user-images.githubusercontent.com/13931806/166942157-43c91ed9-2326-46b2-bef0-4818804c44f8.png)
