### PR TITLE
switch to auto-increment ResourceId

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -88,10 +88,21 @@ where
 		// Check NFT lock status
 		ensure!(!Pallet::<T>::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
 
-		let res = ResourceInfo::<
-			BoundedVec<u8, T::StringLimit>,
-			BoundedVec<PartId, T::PartsLimit>,
-		> {
+		match resource.clone() {
+			ResourceTypes::Basic(_r) => (),
+			ResourceTypes::Composable(r) => {
+				ComposableResources::<T>::insert((collection_id, nft_id, r.base), ());
+			},
+			ResourceTypes::Slot(r) => {
+				SlotResources::<T>::insert(
+					(collection_id, nft_id, resource_id, r.base, r.slot),
+					(),
+				);
+			},
+		}
+
+		let res: ResourceInfo<BoundedVec<u8, T::StringLimit>, BoundedVec<PartId, T::PartsLimit>> =
+			ResourceInfo::<BoundedVec<u8, T::StringLimit>, BoundedVec<PartId, T::PartsLimit>> {
 			id: resource_id,
 			pending: root_owner != sender,
 			pending_removal: false,

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -156,6 +156,34 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
+	#[pallet::getter(fn composable_resources)]
+	/// Stores resource info
+	pub type ComposableResources<T: Config> = StorageNMap<
+		_,
+		(
+			NMapKey<Blake2_128Concat, CollectionId>,
+			NMapKey<Blake2_128Concat, NftId>,
+			NMapKey<Blake2_128Concat, BaseId>,
+		),
+		(),
+	>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn slot_resources)]
+	/// Stores resource info
+	pub type SlotResources<T: Config> = StorageNMap<
+		_,
+		(
+			NMapKey<Blake2_128Concat, CollectionId>,
+			NMapKey<Blake2_128Concat, NftId>,
+			NMapKey<Blake2_128Concat, ResourceId>,
+			NMapKey<Blake2_128Concat, BaseId>,
+			NMapKey<Blake2_128Concat, SlotId>,
+		),
+		(),
+	>;
+
+	#[pallet::storage]
 	#[pallet::getter(fn properties)]
 	/// Metadata of an asset class.
 	pub(super) type Properties<T: Config> = StorageNMap<

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -643,28 +643,17 @@ fn burn_nft_works() {
 		assert_ok!(basic_mint());
 		// Add two resources to NFT (to test if burning also burns the resources)
 
-		let basic_resource = BasicResource {
-			src: None,
-			metadata: None,
-			license: None,
-			thumb: None,
-		};
+		let basic_resource =
+			BasicResource { src: None, metadata: None, license: None, thumb: None };
 
 		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			0,
 			0,
-			stbr("res-1"),
 			basic_resource.clone(),
 		));
 
-		assert_ok!(RMRKCore::add_basic_resource(
-			Origin::signed(ALICE),
-			0,
-			0,
-			stbr("res-2"),
-			basic_resource,
-		));
+		assert_ok!(RMRKCore::add_basic_resource(Origin::signed(ALICE), 0, 0, basic_resource,));
 
 		// Ensure resources are there
 		assert_eq!(Resources::<Test>::iter_prefix((COLLECTION_ID_0, NFT_ID_0)).count(), 2);
@@ -706,19 +695,14 @@ fn burn_nft_with_great_grandchildren_works() {
 			assert_ok!(basic_mint());
 		}
 
-		let basic_resource = BasicResource {
-			src: None,
-			metadata: None,
-			license: None,
-			thumb: None,
-		};
-		
+		let basic_resource =
+			BasicResource { src: None, metadata: None, license: None, thumb: None };
+
 		// Add two resources to the great-grandchild (0, 3)
 		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			3,
-			stbr("res-1"),
 			basic_resource.clone(),
 		));
 
@@ -726,7 +710,6 @@ fn burn_nft_with_great_grandchildren_works() {
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			3,
-			stbr("res-2"),
 			basic_resource,
 		));
 
@@ -827,20 +810,15 @@ fn burn_nft_beyond_max_recursions_fails_gracefully() {
 #[test]
 fn create_resource_works() {
 	ExtBuilder::default().build().execute_with(|| {
-		let basic_resource = BasicResource {
-			src: None,
-			metadata: None,
-			license: None,
-			thumb: None,
-		};
+		let basic_resource =
+			BasicResource { src: None, metadata: None, license: None, thumb: None };
 
 		// Adding a resource to non-existent NFT should fail
 		assert_noop!(
 			RMRKCore::add_basic_resource(
 				Origin::signed(ALICE),
-				0,             // collection_id
-				0,             // nft_id
-				stbr("res-1"), // resource_id
+				0, // collection_id
+				0, // nft_id
 				basic_resource,
 			),
 			Error::<Test>::CollectionUnknown
@@ -850,28 +828,23 @@ fn create_resource_works() {
 		// Mint NFT
 		assert_ok!(basic_mint());
 
-		let basic_resource = BasicResource {
-			src: None,
-			metadata: None,
-			license: None,
-			thumb: None,
-		};
+		let basic_resource =
+			BasicResource { src: None, metadata: None, license: None, thumb: None };
 
 		// Add resource to NFT
 		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			stbr("res-3"), // resource_id
 			basic_resource,
 		));
 		// Successful resource addition should trigger ResourceAdded event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAdded {
 			nft_id: 0,
-			resource_id: stbr("res-3"), // resource_id
+			resource_id: 0, // resource_id
 		}));
 		// Since ALICE rootowns NFT, pending status of resource should be false
-		assert_eq!(RMRKCore::resources((0, 0, stbr("res-3"))).unwrap().pending, false);
+		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, false);
 
 		// Create Composable resource
 		let composable_resource = ComposableResource {
@@ -891,7 +864,7 @@ fn create_resource_works() {
 			stbr("res-3"), // resource_id
 			composable_resource,
 		));
-		
+
 		// Create Slot resource
 		let slot_resource = SlotResource {
 			src: Some(stbd("slot-resource")),
@@ -907,7 +880,6 @@ fn create_resource_works() {
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			stbr("res-3"), // resource_id
 			slot_resource,
 		));
 	});
@@ -942,7 +914,6 @@ fn add_resource_pending_works() {
 				Origin::signed(BOB),
 				COLLECTION_ID_0,
 				NFT_ID_0,
-				stbr("res-4"), // resource_id
 				basic_resource.clone(),
 			),
 			Error::<Test>::NoPermission
@@ -953,28 +924,27 @@ fn add_resource_pending_works() {
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			stbr("res-4"), // resource_id
 			basic_resource
 		));
 
-		assert_eq!(RMRKCore::resources((0, 0, stbr("res-4"))).unwrap().pending, true);
+		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, true);
 		// ALICE doesn't own BOB's NFT, so accept should fail
 		assert_noop!(
-			RMRKCore::accept_resource(Origin::signed(ALICE), 0, 0, stbr("res-4")),
+			RMRKCore::accept_resource(Origin::signed(ALICE), 0, 0, 0),
 			Error::<Test>::NoPermission
 		);
 		// BOB can accept his own NFT's pending resource
-		assert_ok!(RMRKCore::accept_resource(Origin::signed(BOB), 0, 0, stbr("res-4")));
+		assert_ok!(RMRKCore::accept_resource(Origin::signed(BOB), 0, 0, 0));
 		// Valid resource acceptance should trigger a ResourceAccepted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceAccepted {
 			nft_id: 0,
-			resource_id: stbr("res-4"), // resource_id
+			resource_id: 0, // resource_id
 		}));
 		// Resource should now have false pending status
-		assert_eq!(RMRKCore::resources((0, 0, stbr("res-4"))).unwrap().pending, false);
+		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending, false);
 		// Accepting resource again should fail with ResourceNotPending
 		assert_noop!(
-			RMRKCore::accept_resource(Origin::signed(BOB), 0, 0, stbr("res-4")),
+			RMRKCore::accept_resource(Origin::signed(BOB), 0, 0, 0),
 			Error::<Test>::ResourceNotPending
 		);
 	});
@@ -989,19 +959,14 @@ fn resource_removal_works() {
 		// Mint NFT
 		assert_ok!(basic_mint());
 
-		let basic_resource = BasicResource {
-			src: None,
-			metadata: None,
-			license: None,
-			thumb: None,
-		};
+		let basic_resource =
+			BasicResource { src: None, metadata: None, license: None, thumb: None };
 
 		// Add resource to NFT
 		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			stbr("res-0"), // resource_id
 			basic_resource,
 		));
 		// Resource res-1 doesn't exist
@@ -1010,7 +975,7 @@ fn resource_removal_works() {
 				Origin::signed(ALICE),
 				COLLECTION_ID_0,
 				NFT_ID_0,
-				stbr("res-1"), // resource_id
+				1, // resource_id
 			),
 			Error::<Test>::ResourceDoesntExist
 		);
@@ -1020,7 +985,7 @@ fn resource_removal_works() {
 				Origin::signed(BOB),
 				COLLECTION_ID_0,
 				NFT_ID_0,
-				stbr("res-0"), // resource_id
+				0, // resource_id
 			),
 			Error::<Test>::NoPermission
 		);
@@ -1029,15 +994,15 @@ fn resource_removal_works() {
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			stbr("res-0"), // resource_id
+			0, // resource_id
 		));
 		// Successful resource removal should trigger ResourceRemoval event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceRemoval {
 			nft_id: 0,
-			resource_id: stbr("res-0"), // resource_id
+			resource_id: 0, // resource_id
 		}));
 		// Since ALICE rootowns NFT, resource should be removed
-		assert_eq!(RMRKCore::resources((0, 0, stbr("res-0"))), None);
+		assert_eq!(RMRKCore::resources((0, 0, 0)), None);
 	});
 }
 
@@ -1057,31 +1022,21 @@ fn resource_removal_pending_works() {
 			bvec![0u8; 20],
 		));
 
-		let basic_resource = BasicResource {
-			src: None,
-			metadata: None,
-			license: None,
-			thumb: None,
-		};
+		let basic_resource =
+			BasicResource { src: None, metadata: None, license: None, thumb: None };
 
 		// Add resource to NFT
 		assert_ok!(RMRKCore::add_basic_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			stbr("res-0"), // resource_id
 			basic_resource,
 		));
 
-		assert_ok!(RMRKCore::accept_resource(
-			Origin::signed(BOB),
-			COLLECTION_ID_0,
-			NFT_ID_0,
-			stbr("res-0"),
-		));
+		assert_ok!(RMRKCore::accept_resource(Origin::signed(BOB), COLLECTION_ID_0, NFT_ID_0, 0,));
 		// Accepting a resource removal that is not pending should fail
 		assert_noop!(
-			RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, stbr("res-0")),
+			RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, 0),
 			Error::<Test>::ResourceNotPending
 		);
 		// Only collection's issuer can request resource removal
@@ -1090,7 +1045,7 @@ fn resource_removal_pending_works() {
 				Origin::signed(BOB),
 				COLLECTION_ID_0,
 				NFT_ID_0,
-				stbr("res-0"), // resource_id
+				0, // resource_id
 			),
 			Error::<Test>::NoPermission
 		);
@@ -1099,29 +1054,29 @@ fn resource_removal_pending_works() {
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			stbr("res-0"), // resource_id
+			0, // resource_id
 		));
 		// Since ALICE doesn't root-own NFT, resource's removal is waiting for acceptance
-		assert_eq!(RMRKCore::resources((0, 0, stbr("res-0"))).unwrap().pending_removal, true);
+		assert_eq!(RMRKCore::resources((0, 0, 0)).unwrap().pending_removal, true);
 		// ALICE doesn't own BOB's NFT, so accept should fail
 		assert_noop!(
-			RMRKCore::accept_resource_removal(Origin::signed(ALICE), 0, 0, stbr("res-0")),
+			RMRKCore::accept_resource_removal(Origin::signed(ALICE), 0, 0, 0),
 			Error::<Test>::NoPermission
 		);
 		// Resource res-1 doesn't exist
 		assert_noop!(
-			RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, stbr("res-1")),
+			RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, 1),
 			Error::<Test>::ResourceDoesntExist
 		);
 		// BOB can accept his own NFT's pending resource removal
-		assert_ok!(RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, stbr("res-0")));
+		assert_ok!(RMRKCore::accept_resource_removal(Origin::signed(BOB), 0, 0, 0));
 		// Successful resource removal acceptance should trigger ResourceRemovalAccepted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::ResourceRemovalAccepted {
 			nft_id: 0,
-			resource_id: stbr("res-0"), // resource_id
+			resource_id: 0, // resource_id
 		}));
 		// Resource removed
-		assert_eq!(RMRKCore::resources((0, 0, stbr("res-0"))), None);
+		assert_eq!(RMRKCore::resources((0, 0, 0)), None);
 	});
 }
 

--- a/pallets/rmrk-equip/src/functions.rs
+++ b/pallets/rmrk-equip/src/functions.rs
@@ -250,18 +250,17 @@ where
 
 		// initialized so the compiler doesn't complain, though it will be overwritten if it
 		// resource exists
-		let mut to_equip_resource_id: BoundedResource<T> = b"".to_vec().try_into().unwrap();
+		let mut to_equip_resource_id: ResourceId = 0_u32.into();
 
 		let resources_matching_base_iter =
 			pallet_rmrk_core::Resources::<T>::iter_prefix_values((item_collection_id, item_nft_id));
 
 		for resource in resources_matching_base_iter {
 			match resource.resource {
-				ResourceTypes::Slot(res) => {
+				ResourceTypes::Slot(res) =>
 					if res.slot == slot_id && res.base == base_id {
 						found_base_slot_resource_on_nft = true;
 						to_equip_resource_id = resource.id;
-					}
 				},
 				_ => (),
 			}

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
 			NMapKey<Blake2_128Concat, BaseId>,                // Base ID
 			NMapKey<Blake2_128Concat, SlotId>,                // Slot ID
 		),
-		BoundedResource<T>, // Equipped Resource
+		ResourceId, // Equipped Resource
 		OptionQuery,
 	>;
 

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -253,13 +253,14 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			item: (CollectionId, NftId),
 			equipper: (CollectionId, NftId),
+			resource_id: ResourceId,
 			base: BaseId,
 			slot: SlotId,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
 			let (collection_id, nft_id, base_id, slot_id, equipped) =
-				Self::do_equip(sender, item, equipper, base, slot)?;
+				Self::do_equip(sender, item, equipper, resource_id, base, slot)?;
 
 			if equipped {
 				// Send Equip event

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -213,6 +213,7 @@ fn equip_works() {
 				Origin::signed(ALICE), // Signer
 				(1, 0),                // item
 				(0, 0),                // equipper
+				0,                     // ResourceId (doesn't exist)
 				0,                     // BaseId
 				201,                   // SlotId
 			),
@@ -234,6 +235,7 @@ fn equip_works() {
 				Origin::signed(ALICE), // Signer
 				(1, 0),                // item
 				(0, 0),                // equipper
+				0,                     // ResourceId
 				0,                     // BaseId
 				201,                   // SlotId
 			),
@@ -277,6 +279,7 @@ fn equip_works() {
 				Origin::signed(ALICE), // Signer
 				(1, 0),                // item
 				(0, 0),                // equipper
+				0,                     // ResourceId
 				0,                     // BaseId
 				201,                   // SlotId
 			),
@@ -305,6 +308,7 @@ fn equip_works() {
 			Origin::signed(ALICE), // Signer
 			(1, 0),                // item
 			(0, 0),                // equipper
+			0,                     // ResourceId,
 			0,                     // BaseId
 			201,                   // SlotId
 		));
@@ -347,6 +351,7 @@ fn equip_works() {
 				Origin::signed(ALICE), // Signer
 				(1, 0),                // item
 				(0, 0),                // equipper
+				0,                     // ResourceId
 				0,                     // BaseId
 				202,                   // SlotId
 			),
@@ -358,6 +363,7 @@ fn equip_works() {
 			Origin::signed(ALICE), // Signer
 			(1, 0),                // item
 			(0, 0),                // equipper
+			0,                     // ResourceId
 			0,                     // BaseId
 			201,                   // SlotId
 		));
@@ -374,6 +380,7 @@ fn equip_works() {
 			Origin::signed(ALICE), // Signer
 			(1, 0),                // item
 			(0, 0),                // equipper
+			0,                     // ResourceId
 			0,                     // BaseId
 			201,                   // SlotId
 		));
@@ -383,6 +390,7 @@ fn equip_works() {
 			Origin::signed(ALICE), // Signer
 			(1, 0),                // item
 			(0, 0),                // equipper
+			0,                     // ResourceId
 			0,                     // BaseId
 			201,                   // SlotId
 		));
@@ -392,6 +400,7 @@ fn equip_works() {
 			Origin::signed(ALICE), // Signer
 			(1, 0),                // item
 			(0, 0),                // equipper
+			1,                     // ResourceId
 			0,                     // BaseId
 			202,                   // SlotId
 		));

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -253,9 +253,9 @@ fn equip_works() {
 		// Add a Base 0 resource (body-1 and left-hand slot) to our character-0 nft
 		assert_ok!(RmrkCore::add_composable_resource(
 			Origin::signed(ALICE),
-			0,                              // collection_id
-			0,                              // nft id
-			stbr("res-1"),                  // resource_id
+			0,             // collection_id
+			0,             // nft id
+			stbr("res-1"), // resource_id
 			composable_resource,
 			// Some(0),                        // pub base: BaseId,
 			// Some(stb("ipfs://backup-src")), // pub src: BoundedString,
@@ -295,9 +295,8 @@ fn equip_works() {
 		// Add our sword left-hand resource to our sword NFT
 		assert_ok!(RmrkCore::add_slot_resource(
 			Origin::signed(ALICE),
-			1,                                       // collection id
-			0,                                       // nft id
-			stbr("res-777"),                         // resource_id
+			1, // collection id
+			0, // nft id
 			sword_slot_resource_left
 		));
 
@@ -317,10 +316,10 @@ fn equip_works() {
 			slot_id: 201,
 		}));
 
-		// Equipped resource ID Some(777) should now be associated with equippings for character-0
+		// Equipped resource ID 0 should now be associated with equippings for character-0
 		// on base 0, slot 201
 		let equipped = RmrkEquip::equippings(((0, 0), 0, 201));
-		assert_eq!(equipped.clone().unwrap(), stbr("res-777"),);
+		assert_eq!(equipped.clone().unwrap(), 0,);
 
 		// Resource for equipped item should exist
 		assert!(RmrkCore::resources((1, 0, equipped.unwrap())).is_some());
@@ -337,9 +336,8 @@ fn equip_works() {
 		// Add our sword right-hand resource to our sword NFT
 		assert_ok!(RmrkCore::add_slot_resource(
 			Origin::signed(ALICE),
-			1,                                        // collection id
-			0,                                        // nft id
-			stbr("res-130"),                          // resource_id
+			1, // collection id
+			0, // nft id
 			sword_slot_resource_right,
 		));
 

--- a/traits/src/base.rs
+++ b/traits/src/base.rs
@@ -2,7 +2,7 @@ use super::{
 	part::{EquippableList, PartType},
 	theme::Theme,
 };
-use crate::primitives::{BaseId, SlotId};
+use crate::primitives::{BaseId, SlotId, ResourceId};
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_runtime::{DispatchError, RuntimeDebug};
@@ -39,6 +39,7 @@ pub trait Base<AccountId, CollectionId, NftId, BoundedString, BoundedParts, Boun
 		issuer: AccountId, // Maybe don't need?
 		item: (CollectionId, NftId),
 		equipper: (CollectionId, NftId),
+		resource_id: ResourceId,
 		base_id: BaseId, // Maybe BaseId ?
 		slot: SlotId,    // Maybe SlotId ?
 	) -> Result<(CollectionId, NftId, BaseId, SlotId, bool), DispatchError>;

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::too_many_arguments)]
 
 use codec::{Decode, Encode};
+use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_runtime::{DispatchResult, RuntimeDebug};
-use sp_std::{cmp::Eq, vec::Vec};
-use frame_support::pallet_prelude::MaxEncodedLen;
+use sp_runtime::{DispatchError, DispatchResult, RuntimeDebug};
+use sp_std::{cmp::Eq, result::Result, vec::Vec};
 
 use crate::primitives::*;
 
@@ -108,57 +108,49 @@ pub enum ResourceTypes<BoundedString, BoundedParts> {
 	Slot(SlotResource<BoundedString>),
 }
 
-
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ResourceInfo<BoundedResource, BoundedString, BoundedParts> {
+pub struct ResourceInfo<BoundedString, BoundedParts> {
 	/// id is a 5-character string of reasonable uniqueness.
 	/// The combination of base ID and resource id should be unique across the entire RMRK
 	/// ecosystem which
-	pub id: BoundedResource,
-	
+	pub id: ResourceId,
+
 	/// Resource
 	pub resource: ResourceTypes<BoundedString, BoundedParts>,
 
 	/// If resource is sent to non-rootowned NFT, pending will be false and need to be accepted
 	pub pending: bool,
 
-	/// If resource removal request is sent by non-rootowned NFT, pending will be true and need to be accepted
+	/// If resource removal request is sent by non-rootowned NFT, pending will be true and need to
+	/// be accepted
 	pub pending_removal: bool,
 }
 
 /// Abstraction over a Resource system.
-pub trait Resource<BoundedString, AccountId, BoundedResource, BoundedPart> {
+pub trait Resource<BoundedString, AccountId, BoundedPart> {
 	fn resource_add(
 		sender: AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
-		resource_id: BoundedResource,
 		resource: ResourceTypes<BoundedString, BoundedPart>,
-		// base: Option<BaseId>,
-		// src: Option<BoundedString>,
-		// metadata: Option<BoundedString>,
-		// slot: Option<SlotId>,
-		// license: Option<BoundedString>,
-		// thumb: Option<BoundedString>,
-		// parts: Option<BoundedPart>,
-	) -> DispatchResult;
+	) -> Result<ResourceId, DispatchError>;
 	fn accept(
 		sender: AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
-		resource_id: BoundedResource,
+		resource_id: ResourceId,
 	) -> DispatchResult;
 	fn resource_remove(
 		sender: AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
-		resource_id: BoundedResource,
+		resource_id: ResourceId,
 	) -> DispatchResult;
 	fn accept_removal(
 		sender: AccountId,
 		collection_id: CollectionId,
 		nft_id: NftId,
-		resource_id: BoundedResource,
+		resource_id: ResourceId,
 	) -> DispatchResult;
 }


### PR DESCRIPTION
addresses #138 
One issue that remains is that id is part of the `Resource` struct.  I don't think this is necessary generally.  For example, Nft and Collection don't have their respective IDs as part of their struct.  However, we need to extract the resource ID when doing an iter_prefix_values for the CollectionID, NftId inside the `do_equip` function (we do this when checking for the existence of a BaseId+SlotId on the resources for a Slot Resource -- that is, ensuring that there exists a Slot Resource matching the BaseId and SlotId passed to the equip extrinsic).

https://github.com/rmrk-team/rmrk-substrate/blob/218fe30a8950ab0acf51976246fcd6b812aa8a87/pallets/rmrk-equip/src/functions.rs#L255-L268

We could either figure out how to get the key value when iterating through with `iter_prefix_values` (I asked the question in StackExchange [here](https://substrate.stackexchange.com/questions/2767/get-value-and-key-from-iter-prefix-values)), or find a more graceful way of checking altogether.

For now, holding the `id` in the struct works.