### PR TITLE
remove parent's child when child burned

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -313,6 +313,14 @@ where
 		max_recursions: u32,
 	) -> sp_std::result::Result<(CollectionId, NftId), DispatchError> {
 		ensure!(max_recursions > 0, Error::<T>::TooManyRecursions);
+
+		// Remove self from parent's Children storage
+		if let Some(nft) = Self::nfts(collection_id, nft_id) {
+			if let AccountIdOrCollectionNftTuple::CollectionAndNftTuple(parent_col, parent_nft) = nft.owner {
+				Children::<T>::remove((parent_col, parent_nft), (collection_id, nft_id));
+			}
+		}
+
 		Nfts::<T>::remove(collection_id, nft_id);
 
 		Resources::<T>::remove_prefix((collection_id, nft_id), None);

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -823,6 +823,37 @@ fn burn_nft_beyond_max_recursions_fails_gracefully() {
 	});
 }
 
+/// NFT: Burn child removes NFT from owner-NFT's Children list
+#[test]
+fn burn_child_nft_removes_parents_children() {
+	ExtBuilder::default().build().execute_with(|| {
+		// Create a basic collection
+		assert_ok!(basic_collection());
+		// Mint NFTs (0, 0), (0, 1), (0, 2), (0, 3)
+		for _ in 0..2 {
+			assert_ok!(basic_mint());
+		}
+		// ALICE sends NFT (0, 1) to NFT (0, 0)
+		assert_ok!(RMRKCore::send(
+			Origin::signed(ALICE),
+			0,
+			1,
+			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0),
+		));
+		// All NFTs exist
+		assert_eq!(RMRKCore::nfts(COLLECTION_ID_0, 0).is_some(), true);
+		assert_eq!(RMRKCore::nfts(COLLECTION_ID_0, 1).is_some(), true);
+		// NFT (0, 0) should have 1 Children storage member
+		assert_eq!(Children::<Test>::iter_prefix((0, 0)).count(), 1);
+		// Burn NFT (0, 1)
+		assert_ok!(
+			RMRKCore::burn_nft(Origin::signed(ALICE), 0, 1),
+		);
+		// NFT (0, 0) should have 0 Children storage members
+		assert_eq!(Children::<Test>::iter_prefix((0, 0)).count(), 0);
+	});
+}
+
 /// Resource: Basic resource addition (RMRK2.0 spec: RESADD)
 #[test]
 fn create_resource_works() {


### PR DESCRIPTION
addresses #148, we weren't removing child from *parent* in the event of a burn.  easy fix (hopefully).