### PR TITLE
allow minting directly to nft

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -350,7 +350,7 @@ where
 		}
 
 		// Calculate the rootowner of the intended owner of the minted NFT
-		let rootowner = Self::lookup_root_owner(owner.0, owner.1)?.0;
+		let (rootowner, _) = Self::lookup_root_owner(owner.0, owner.1)?;
 
 		// NFT should be pending if minting either to an NFT owned by another account
 		let pending = rootowner != sender;

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -383,17 +383,17 @@ pub mod pallet {
 				transferable,
 			)?;
 
-			// Extract rootowner (needs calculated if minting directly to NFT)
-			let rootowner = match nft_owner.clone() {
+			// For Uniques, we need to decode the "virtual account" ID to be the owner
+			let uniques_owner = match nft_owner.clone() {
 				AccountIdOrCollectionNftTuple::AccountId(account_id) => account_id,
-				AccountIdOrCollectionNftTuple::CollectionAndNftTuple(col_id, nft_id) =>
-					Self::lookup_root_owner(col_id, nft_id)?.0,
+				AccountIdOrCollectionNftTuple::CollectionAndNftTuple(collection_id, nft_id) =>
+					Self::nft_to_account_id(collection_id, nft_id),
 			};
 
 			pallet_uniques::Pallet::<T>::do_mint(
 				collection_id,
 				nft_id,
-				rootowner.clone(),
+				uniques_owner,
 				|_details| Ok(()),
 			)?;
 

--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -374,7 +374,7 @@ pub mod pallet {
 
 			// Mint NFT for RMRK storage
 			let (collection_id, nft_id) = Self::nft_mint(
-				sender,
+				sender.clone(),
 				nft_owner.clone(),
 				collection_id,
 				royalty_recipient,
@@ -399,7 +399,7 @@ pub mod pallet {
 
 			if let Some(resources) = resources {
 				for res in resources {
-					Self::resource_add(rootowner.clone(), collection_id, nft_id, res)?;
+					Self::resource_add(sender.clone(), collection_id, nft_id, res, true)?;
 				}
 			}
 
@@ -661,8 +661,13 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
 
-			let resource_id =
-				Self::resource_add(sender, collection_id, nft_id, ResourceTypes::Basic(resource))?;
+			let resource_id = Self::resource_add(
+				sender,
+				collection_id,
+				nft_id,
+				ResourceTypes::Basic(resource),
+				false,
+			)?;
 
 			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
 			Ok(())
@@ -685,6 +690,7 @@ pub mod pallet {
 				collection_id,
 				nft_id,
 				ResourceTypes::Composable(resource),
+				false,
 			)?;
 
 			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
@@ -702,8 +708,13 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
 
-			let resource_id =
-				Self::resource_add(sender, collection_id, nft_id, ResourceTypes::Slot(resource))?;
+			let resource_id = Self::resource_add(
+				sender,
+				collection_id,
+				nft_id,
+				ResourceTypes::Slot(resource),
+				false,
+			)?;
 
 			Self::deposit_event(Event::ResourceAdded { nft_id, resource_id });
 			Ok(())

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -54,7 +54,7 @@ fn basic_collection() -> DispatchResult {
 fn basic_mint() -> DispatchResult {
 	RMRKCore::mint_nft(
 		Origin::signed(ALICE),
-		ALICE,
+		AccountIdOrCollectionNftTuple::AccountId(ALICE),
 		COLLECTION_ID_0,
 		Some(ALICE),
 		Some(Permill::from_float(1.525)),
@@ -119,7 +119,7 @@ fn create_collection_no_max_works() {
 		}
 		// Last event should be the 100th NFT creation
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NftMinted {
-			owner: ALICE,
+			owner: AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			collection_id: 0,
 			nft_id: 99,
 		}));
@@ -227,7 +227,7 @@ fn mint_nft_works() {
 		assert_ok!(basic_mint());
 		// Minting an NFT should trigger an NftMinted event
 		System::assert_last_event(MockEvent::RmrkCore(crate::Event::NftMinted {
-			owner: ALICE,
+			owner: AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			collection_id: 0,
 			nft_id: 0,
 		}));
@@ -235,7 +235,7 @@ fn mint_nft_works() {
 		assert_eq!(RMRKCore::collections(COLLECTION_ID_0).unwrap().nfts_count, 1);
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(20.525)),
@@ -247,7 +247,7 @@ fn mint_nft_works() {
 		assert_noop!(
 			RMRKCore::mint_nft(
 				Origin::signed(BOB),
-				BOB,
+				AccountIdOrCollectionNftTuple::AccountId(BOB),
 				COLLECTION_ID_0,
 				Some(CHARLIE),
 				Some(Permill::from_float(20.525)),
@@ -261,7 +261,7 @@ fn mint_nft_works() {
 		assert_noop!(
 			RMRKCore::mint_nft(
 				Origin::signed(ALICE),
-				ALICE,
+				AccountIdOrCollectionNftTuple::AccountId(ALICE),
 				NOT_EXISTING_CLASS_ID,
 				Some(CHARLIE),
 				Some(Permill::from_float(20.525)),
@@ -302,7 +302,7 @@ fn royalty_recipient_default_works() {
 		// Mint an NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			None, // No royalty recipient
 			Some(Permill::from_float(20.525)),
@@ -315,7 +315,7 @@ fn royalty_recipient_default_works() {
 		// Mint another NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			Some(BOB), // Royalty recipient is BOB
 			Some(Permill::from_float(20.525)),
@@ -328,7 +328,7 @@ fn royalty_recipient_default_works() {
 		// Mint another NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			None, // No royalty recipient is BOB
 			None, // No royalty amount
@@ -341,7 +341,7 @@ fn royalty_recipient_default_works() {
 		// Mint another NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE), // Royalty recipient is ALICE
 			None,        // No royalty amount
@@ -513,7 +513,7 @@ fn send_non_transferable_fail() {
 		// Mint non-transferable NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -584,7 +584,7 @@ fn reject_nft_removes_self_from_parents_children() {
 		// Alice mints (0, 1) for Bob
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			BOB,
+			AccountIdOrCollectionNftTuple::AccountId(BOB),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -1018,7 +1018,7 @@ fn add_resource_on_mint_works() {
 		// Mint NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -1057,7 +1057,7 @@ fn add_resource_on_mint_beyond_max_fails() {
 		// Mint NFT
 		RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -1077,7 +1077,7 @@ fn add_resource_pending_works() {
 		// Mint NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			BOB,
+			AccountIdOrCollectionNftTuple::AccountId(BOB),
 			COLLECTION_ID_0,
 			Some(BOB),
 			Some(Permill::from_float(1.525)),
@@ -1200,7 +1200,7 @@ fn resource_removal_pending_works() {
 		// Mint NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			BOB,
+			AccountIdOrCollectionNftTuple::AccountId(BOB),
 			COLLECTION_ID_0,
 			Some(BOB),
 			Some(Permill::from_float(1.525)),

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -247,7 +247,7 @@ fn mint_nft_works() {
 		assert_noop!(
 			RMRKCore::mint_nft(
 				Origin::signed(BOB),
-				Some(AccountIdOrCollectionNftTuple::AccountId(BOB)),
+				Some(BOB),
 				COLLECTION_ID_0,
 				Some(CHARLIE),
 				Some(Permill::from_float(20.525)),
@@ -261,7 +261,7 @@ fn mint_nft_works() {
 		assert_noop!(
 			RMRKCore::mint_nft(
 				Origin::signed(ALICE),
-				Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+				Some(ALICE),
 				NOT_EXISTING_CLASS_ID,
 				Some(CHARLIE),
 				Some(Permill::from_float(20.525)),
@@ -283,9 +283,9 @@ fn mint_directly_to_nft() {
 
 		// Mint directly to non-existent NFT fails
 		assert_noop!(
-			RMRKCore::mint_nft(
+			RMRKCore::mint_nft_directly_to_nft(
 				Origin::signed(ALICE),
-				Some(AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0)),
+				(0, 0),
 				COLLECTION_ID_0,
 				None,
 				Some(Permill::from_float(20.525)),
@@ -299,7 +299,7 @@ fn mint_directly_to_nft() {
 		// ALICE mints an NFT for BOB
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(BOB)),
+			Some(BOB),
 			COLLECTION_ID_0,
 			None,
 			Some(Permill::from_float(20.525)),
@@ -315,9 +315,9 @@ fn mint_directly_to_nft() {
 		);
 
 		// ALICE mints NFT directly to BOB-owned NFT (0, 0)
-		assert_ok!(RMRKCore::mint_nft(
+		assert_ok!(RMRKCore::mint_nft_directly_to_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0)),
+			(0, 0),
 			COLLECTION_ID_0,
 			None,
 			Some(Permill::from_float(20.525)),
@@ -351,7 +351,7 @@ fn mint_directly_to_nft_with_resources() {
 		// ALICE mints an NFT for BOB
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(BOB)),
+			Some(BOB),
 			COLLECTION_ID_0,
 			None,
 			Some(Permill::from_float(20.525)),
@@ -368,9 +368,9 @@ fn mint_directly_to_nft_with_resources() {
 		let resources_to_add = bvec![ResourceTypes::Basic(basic_resource)];
 
 		// ALICE mints NFT directly to BOB-owned NFT (0, 0), with the above resource
-		assert_ok!(RMRKCore::mint_nft(
+		assert_ok!(RMRKCore::mint_nft_directly_to_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0)),
+			(0, 0),
 			COLLECTION_ID_0,
 			None,
 			Some(Permill::from_float(20.525)),
@@ -416,7 +416,7 @@ fn royalty_recipient_default_works() {
 		// Mint an NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			None, // No royalty recipient
 			Some(Permill::from_float(20.525)),
@@ -429,7 +429,7 @@ fn royalty_recipient_default_works() {
 		// Mint another NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			Some(BOB), // Royalty recipient is BOB
 			Some(Permill::from_float(20.525)),
@@ -442,7 +442,7 @@ fn royalty_recipient_default_works() {
 		// Mint another NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			None, // No royalty recipient is BOB
 			None, // No royalty amount
@@ -455,7 +455,7 @@ fn royalty_recipient_default_works() {
 		// Mint another NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE), // Royalty recipient is ALICE
 			None,        // No royalty amount
@@ -627,7 +627,7 @@ fn send_non_transferable_fail() {
 		// Mint non-transferable NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -656,7 +656,7 @@ fn mint_non_transferrable_gem_on_to_nft_works() {
 		// Mint NFT (transferrable, will be the parent of a later-minted non-transferrable NFT)
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(BOB)),
+			Some(BOB),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -666,9 +666,9 @@ fn mint_non_transferrable_gem_on_to_nft_works() {
 		));
 
 		// Mint non-transferable NFT *on to* Bob-owned NFT (0, 0)
-		assert_ok!(RMRKCore::mint_nft(
+		assert_ok!(RMRKCore::mint_nft_directly_to_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0)),
+			(0, 0),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -772,7 +772,7 @@ fn reject_nft_removes_self_from_parents_children() {
 		// Alice mints (0, 1) for Bob
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(BOB)),
+			Some(BOB),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -1206,7 +1206,7 @@ fn add_resource_on_mint_works() {
 		// Mint NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -1242,7 +1242,7 @@ fn add_resource_on_mint_beyond_max_fails() {
 		// Mint NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),
@@ -1262,7 +1262,7 @@ fn add_resource_pending_works() {
 		// Mint NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(BOB)),
+			Some(BOB),
 			COLLECTION_ID_0,
 			Some(BOB),
 			Some(Permill::from_float(1.525)),
@@ -1385,7 +1385,7 @@ fn resource_removal_pending_works() {
 		// Mint NFT
 		assert_ok!(RMRKCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(BOB)),
+			Some(BOB),
 			COLLECTION_ID_0,
 			Some(BOB),
 			Some(Permill::from_float(1.525)),

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -174,11 +174,11 @@ fn equip_works() {
 		// Mint NFT 0 from collection 0 (character-0)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)), // owner
-			0,                                                     // collection ID
-			Some(ALICE),                                           // recipient
-			Some(Permill::from_float(1.525)),                      // royalties
-			stb("ipfs://character-0-metadata"),                    // metadata
+			Some(ALICE),                        // owner
+			0,                                  // collection ID
+			Some(ALICE),                        // recipient
+			Some(Permill::from_float(1.525)),   // royalties
+			stb("ipfs://character-0-metadata"), // metadata
 			true,
 			None,
 		));
@@ -186,11 +186,11 @@ fn equip_works() {
 		// Mint NFT 1 from collection 0 (character-1)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)), // owner
-			0,                                                     // collection ID
-			Some(ALICE),                                           // recipient
-			Some(Permill::from_float(1.525)),                      // royalties
-			stb("ipfs://character-1-metadata"),                    // metadata
+			Some(ALICE),                        // owner
+			0,                                  // collection ID
+			Some(ALICE),                        // recipient
+			Some(Permill::from_float(1.525)),   // royalties
+			stb("ipfs://character-1-metadata"), // metadata
 			true,
 			None,
 		));
@@ -198,11 +198,11 @@ fn equip_works() {
 		// Mint NFT 0 from collection 1 (sword)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)), // owner
-			1,                                                     // collection ID
-			Some(ALICE),                                           // recipient
-			Some(Permill::from_float(1.525)),                      // royalties
-			stb("ipfs://sword-metadata"),                          // metadata
+			Some(ALICE),                      // owner
+			1,                                // collection ID
+			Some(ALICE),                      // recipient
+			Some(Permill::from_float(1.525)), // royalties
+			stb("ipfs://sword-metadata"),     // metadata
 			true,
 			None,
 		));
@@ -210,11 +210,11 @@ fn equip_works() {
 		// Mint NFT 1 from collection 1 (flashlight)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)), // owner
-			1,                                                     // collection ID
-			Some(ALICE),                                           // recipient
-			Some(Permill::from_float(1.525)),                      // royalties
-			stb("ipfs://flashlight-metadata"),                     // metadata
+			Some(ALICE),                       // owner
+			1,                                 // collection ID
+			Some(ALICE),                       // recipient
+			Some(Permill::from_float(1.525)),  // royalties
+			stb("ipfs://flashlight-metadata"), // metadata
 			true,
 			None,
 		));

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -174,11 +174,11 @@ fn equip_works() {
 		// Mint NFT 0 from collection 0 (character-0)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,                              // owner
-			0,                                  // collection ID
-			Some(ALICE),                        // recipient
-			Some(Permill::from_float(1.525)),   // royalties
-			stb("ipfs://character-0-metadata"), // metadata
+			AccountIdOrCollectionNftTuple::AccountId(ALICE), // owner
+			0,                                               // collection ID
+			Some(ALICE),                                     // recipient
+			Some(Permill::from_float(1.525)),                // royalties
+			stb("ipfs://character-0-metadata"),              // metadata
 			true,
 			None,
 		));
@@ -186,11 +186,11 @@ fn equip_works() {
 		// Mint NFT 1 from collection 0 (character-1)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,                              // owner
-			0,                                  // collection ID
-			Some(ALICE),                        // recipient
-			Some(Permill::from_float(1.525)),   // royalties
-			stb("ipfs://character-1-metadata"), // metadata
+			AccountIdOrCollectionNftTuple::AccountId(ALICE), // owner
+			0,                                               // collection ID
+			Some(ALICE),                                     // recipient
+			Some(Permill::from_float(1.525)),                // royalties
+			stb("ipfs://character-1-metadata"),              // metadata
 			true,
 			None,
 		));
@@ -198,11 +198,11 @@ fn equip_works() {
 		// Mint NFT 0 from collection 1 (sword)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,                            // owner
-			1,                                // collection ID
-			Some(ALICE),                      // recipient
-			Some(Permill::from_float(1.525)), // royalties
-			stb("ipfs://sword-metadata"),     // metadata
+			AccountIdOrCollectionNftTuple::AccountId(ALICE), // owner
+			1,                                               // collection ID
+			Some(ALICE),                                     // recipient
+			Some(Permill::from_float(1.525)),                // royalties
+			stb("ipfs://sword-metadata"),                    // metadata
 			true,
 			None,
 		));
@@ -210,11 +210,11 @@ fn equip_works() {
 		// Mint NFT 1 from collection 1 (flashlight)
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,                             // owner
-			1,                                 // collection ID
-			Some(ALICE),                       // recipient
-			Some(Permill::from_float(1.525)),  // royalties
-			stb("ipfs://flashlight-metadata"), // metadata
+			AccountIdOrCollectionNftTuple::AccountId(ALICE), // owner
+			1,                                               // collection ID
+			Some(ALICE),                                     // recipient
+			Some(Permill::from_float(1.525)),                // royalties
+			stb("ipfs://flashlight-metadata"),               // metadata
 			true,
 			None,
 		));

--- a/pallets/rmrk-market/src/tests.rs
+++ b/pallets/rmrk-market/src/tests.rs
@@ -40,7 +40,7 @@ fn basic_collection() -> DispatchResult {
 fn basic_mint() -> DispatchResult {
 	RmrkCore::mint_nft(
 		Origin::signed(ALICE),
-		ALICE,
+		AccountIdOrCollectionNftTuple::AccountId(ALICE),
 		COLLECTION_ID_0,
 		Some(ALICE),
 		Some(Permill::from_float(1.525)),
@@ -128,7 +128,7 @@ fn list_non_transferable_fail() {
 		// Mint non-transferable NFT
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			ALICE,
+			AccountIdOrCollectionNftTuple::AccountId(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),

--- a/pallets/rmrk-market/src/tests.rs
+++ b/pallets/rmrk-market/src/tests.rs
@@ -40,7 +40,7 @@ fn basic_collection() -> DispatchResult {
 fn basic_mint() -> DispatchResult {
 	RmrkCore::mint_nft(
 		Origin::signed(ALICE),
-		Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+		Some(ALICE),
 		COLLECTION_ID_0,
 		Some(ALICE),
 		Some(Permill::from_float(1.525)),
@@ -128,7 +128,7 @@ fn list_non_transferable_fail() {
 		// Mint non-transferable NFT
 		assert_ok!(RmrkCore::mint_nft(
 			Origin::signed(ALICE),
-			Some(AccountIdOrCollectionNftTuple::AccountId(ALICE)),
+			Some(ALICE),
 			COLLECTION_ID_0,
 			Some(ALICE),
 			Some(Permill::from_float(1.525)),

--- a/traits/src/nft.rs
+++ b/traits/src/nft.rs
@@ -57,7 +57,16 @@ pub trait Nft<AccountId, BoundedString> {
 
 	fn nft_mint(
 		sender: AccountId,
-		owner: AccountIdOrCollectionNftTuple<AccountId>,
+		owner: AccountId,
+		collection_id: CollectionId,
+		royalty_recipient: Option<AccountId>,
+		royalty_amount: Option<Permill>,
+		metadata: BoundedString,
+		transferable: bool,
+	) -> Result<(CollectionId, NftId), DispatchError>;
+	fn nft_mint_directly_to_nft(
+		sender: AccountId,
+		owner: (CollectionId, NftId),
 		collection_id: CollectionId,
 		royalty_recipient: Option<AccountId>,
 		royalty_amount: Option<Permill>,

--- a/traits/src/nft.rs
+++ b/traits/src/nft.rs
@@ -57,7 +57,7 @@ pub trait Nft<AccountId, BoundedString> {
 
 	fn nft_mint(
 		sender: AccountId,
-		owner: AccountId,
+		owner: AccountIdOrCollectionNftTuple<AccountId>,
 		collection_id: CollectionId,
 		royalty_recipient: Option<AccountId>,
 		royalty_amount: Option<Permill>,

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -138,6 +138,7 @@ pub trait Resource<BoundedString, AccountId, BoundedPart> {
 		collection_id: CollectionId,
 		nft_id: NftId,
 		resource: ResourceTypes<BoundedString, BoundedPart>,
+		adding_on_mint: bool,
 	) -> Result<ResourceId, DispatchError>;
 	fn accept(
 		sender: AccountId,


### PR DESCRIPTION
This is basic implementation but some missing pieces

- [x] need to add tests:
- [x] mint to nft works, 
- [x] mint to nft fails if nft doesn't exist, 
- [x] mint to non-owned nft results in pending state
- [x] other tests?
- [x] currently i think minting to a non-owned nft with resources will leave each resource in pending state, which is likely undesirable.  we want the resources accepted on minted adds.  two possible solutions: (1) implement an auto-accept right after the resource add inside of the mint [con: bunch of events, maybe more weight], (2) add an `during_mint` parameter to `resource_add`, which would override the requirement for sender to equal owner.  i'd vote for option 2.