### PR TITLE
Fix RPC Equip/Unequip Logic

### DIFF
--- a/pallets/rmrk-equip/src/functions.rs
+++ b/pallets/rmrk-equip/src/functions.rs
@@ -184,6 +184,18 @@ where
 		let item_nft_id = item.1;
 		let equipper_collection_id = equipper.0;
 		let equipper_nft_id = equipper.1;
+
+		// Item must exist
+		let item_exists =
+			pallet_rmrk_core::Pallet::<T>::nft_exists((item_collection_id, item_nft_id));
+		ensure!(item_exists, Error::<T>::ItemDoesntExist);
+
+		// Equipper must exist
+		ensure!(
+			pallet_rmrk_core::Pallet::<T>::nfts(equipper_collection_id, equipper_nft_id).is_some(),
+			Error::<T>::EquipperDoesntExist
+		);
+
 		// Check item NFT lock status
 		ensure!(
 			!pallet_rmrk_core::Pallet::<T>::is_locked(item_collection_id, item_nft_id),
@@ -208,17 +220,6 @@ where
 		ensure!(
 			!Self::slot_is_equipped((equipper_collection_id, equipper_nft_id), base_id, slot_id),
 			Error::<T>::SlotAlreadyEquipped
-		);
-
-		// Item must exist
-		let item_exists =
-			pallet_rmrk_core::Pallet::<T>::nft_exists((item_collection_id, item_nft_id));
-		ensure!(item_exists, Error::<T>::ItemDoesntExist);
-
-		// Equipper must exist
-		ensure!(
-			pallet_rmrk_core::Pallet::<T>::nfts(equipper_collection_id, equipper_nft_id).is_some(),
-			Error::<T>::EquipperDoesntExist
 		);
 
 		// Caller must root-own item

--- a/tests/src/equipNft.test.ts
+++ b/tests/src/equipNft.test.ts
@@ -183,7 +183,7 @@ describe("integration test: Equip NFT", () => {
     const resourceId = 0;
 
     const tx = equipNft(api, Alice, itemNFT, invalidEquipperNFT, resourceId, baseId, slotId);
-    await expectTxFailure(/rmrkCore\.NoAvailableNftId/, tx);
+    await expectTxFailure(/rmrkEquip\.EquipperDoesntExist/, tx);
   });
 
   it("[negative] equip non-existing NFT", async () => {
@@ -206,7 +206,7 @@ describe("integration test: Equip NFT", () => {
     const resourceId = 0;
 
     const tx = equipNft(api, Alice, invalidItemNFT, equipperNFT, resourceId, baseId, slotId);
-    await expectTxFailure(/rmrkCore\.NoAvailableNftId/, tx);
+    await expectTxFailure(/rmrkEquip\.ItemDoesntExist/, tx);
   });
 
   it("[negative] equip NFT by a not-an-owner user", async () => {

--- a/tests/src/removeResource.test.ts
+++ b/tests/src/removeResource.test.ts
@@ -162,7 +162,7 @@ describe('Integration test: remove nft resource', () => {
 
         const newOwnerNFT: NftIdTuple = [collectionIdAlice, parentNftId];
 
-        await sendNft(api, "sent", Bob, collectionIdAlice, childNftId, newOwnerNFT);
+        await sendNft(api, "pending", Bob, collectionIdAlice, childNftId, newOwnerNFT);
 
         await removeNftResource(api, 'pending', Alice, collectionIdAlice, childNftId, resourceId);
         await acceptResourceRemoval(api, Bob, collectionIdAlice, childNftId, resourceId);

--- a/tests/src/util/tx.ts
+++ b/tests/src/util/tx.ts
@@ -1066,7 +1066,7 @@ export async function unequipNft(
 ) {
   const ss58Format = api.registry.getChainProperties()!.toJSON().ss58Format;
   const issuer = privateKey(issuerUri, Number(ss58Format));
-  const tx = api.tx.rmrkEquip.equip(item, equipper, resource, base, slot);
+  const tx = api.tx.rmrkEquip.unequip(item, equipper, base, slot);
   const events = await executeTransaction(api, issuer, tx);
 
   const unEquipResult = extractRmrkEquipTxResult(


### PR DESCRIPTION
## Targets
- [x] Check is NFTs (item to equip & equipper NFT) exists before proceeding in `do_equip`
- [x] Change RPC functions for equip & unequip to handle errors correctly