### PR TITLE
Removing compile warnings

### DIFF
--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -31,7 +31,7 @@ use sp_inherents::{InherentData, InherentDataProvider};
 use sp_keyring::Sr25519Keyring;
 use sp_runtime::{OpaqueExtrinsic, SaturatedConversion};
 
-use rmrk_substrate_runtime::EXISTENTIAL_DEPOSIT;
+// use rmrk_substrate_runtime::EXISTENTIAL_DEPOSIT;
 use std::{sync::Arc, time::Duration};
 
 /// Generates extrinsics for the `benchmark overhead` command.

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -33,7 +33,7 @@ where
 		ensure!(sender == root_owner, Error::<T>::NoPermission);
 		// Check NFT lock status
 		ensure!(!Pallet::<T>::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
-		Priorities::<T>::remove_prefix((collection_id, nft_id), None);
+		let _multi_removal_results =Priorities::<T>::clear_prefix((collection_id, nft_id), T::MaxPriorities::get(),  None);
 		let mut priority_index = 0;
 		for resource_id in priorities {
 			Priorities::<T>::insert((collection_id, nft_id, resource_id), priority_index);
@@ -520,7 +520,7 @@ where
 
 		Nfts::<T>::remove(collection_id, nft_id);
 
-		Resources::<T>::remove_prefix((collection_id, nft_id), None);
+		let _multi_removal_results = Resources::<T>::clear_prefix((collection_id, nft_id), T::MaxResourcesOnMint::get(), None);
 
 		for ((child_collection_id, child_nft_id), _) in
 			Children::<T>::drain_prefix((collection_id, nft_id))
@@ -640,7 +640,7 @@ where
 		ensure!(sender == root_owner, Error::<T>::NoPermission);
 
 		// Get NFT info
-		let mut sending_nft =
+		let _sending_nft =
 			Nfts::<T>::get(collection_id, nft_id).ok_or(Error::<T>::NoAvailableNftId)?;
 
 		// Prepare acceptance
@@ -712,7 +712,7 @@ where
 		}
 
 		// Get NFT info
-		let mut rejecting_nft =
+		let _rejecting_nft =
 			Nfts::<T>::get(collection_id, nft_id).ok_or(Error::<T>::NoAvailableNftId)?;
 
 		Self::nft_burn(collection_id, nft_id, max_recursions)?;

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -33,7 +33,8 @@ where
 		ensure!(sender == root_owner, Error::<T>::NoPermission);
 		// Check NFT lock status
 		ensure!(!Pallet::<T>::is_locked(collection_id, nft_id), pallet_uniques::Error::<T>::Locked);
-		let _multi_removal_results =Priorities::<T>::clear_prefix((collection_id, nft_id), T::MaxPriorities::get(),  None);
+		let _multi_removal_results =
+			Priorities::<T>::clear_prefix((collection_id, nft_id), T::MaxPriorities::get(), None);
 		let mut priority_index = 0;
 		for resource_id in priorities {
 			Priorities::<T>::insert((collection_id, nft_id, resource_id), priority_index);
@@ -520,7 +521,11 @@ where
 
 		Nfts::<T>::remove(collection_id, nft_id);
 
-		let _multi_removal_results = Resources::<T>::clear_prefix((collection_id, nft_id), T::MaxResourcesOnMint::get(), None);
+		let _multi_removal_results = Resources::<T>::clear_prefix(
+			(collection_id, nft_id),
+			T::MaxResourcesOnMint::get(),
+			None,
+		);
 
 		for ((child_collection_id, child_nft_id), _) in
 			Children::<T>::drain_prefix((collection_id, nft_id))

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -7,7 +7,7 @@ use crate as pallet_rmrk_core;
 
 use frame_support::{
 	parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU32, Everything, Locker},
+	traits::{AsEnsureOriginWithArg, ConstU32, Everything},
 	weights::Weight,
 };
 use frame_system::EnsureRoot;
@@ -155,9 +155,6 @@ pub const COLLECTION_ID_0: <Test as pallet_uniques::Config>::CollectionId = 0;
 // pub const COLLECTION_ID_1: <Test as pallet_uniques::Config>::CollectionId = 1;
 pub const NFT_ID_0: <Test as pallet_uniques::Config>::ItemId = 0;
 pub const NOT_EXISTING_CLASS_ID: <Test as pallet_uniques::Config>::CollectionId = 999;
-pub const RESOURCE_ZERO: ResourceId = 0;
-pub const RESOURCE_ONE: ResourceId = 1;
-pub const RESOURCE_TWO: ResourceId = 2;
 pub const MAX_BURNS: u32 = 4;
 
 pub struct ExtBuilder;

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -10,17 +10,12 @@ use sp_runtime::Permill;
 use super::*;
 use mock::{Event as MockEvent, *};
 use pallet_uniques as UNQ;
-use sp_std::{convert::TryInto, vec::Vec};
+use sp_std::convert::TryInto;
 
 type RMRKCore = Pallet<Test>;
 
 /// Turns a string into a BoundedVec
 fn stb(s: &str) -> BoundedVec<u8, ValueLimit> {
-	s.as_bytes().to_vec().try_into().unwrap()
-}
-
-/// Turns a string into a BoundedResource
-fn stbr(s: &str) -> BoundedResource<ResourceSymbolLimit> {
 	s.as_bytes().to_vec().try_into().unwrap()
 }
 
@@ -32,11 +27,6 @@ fn stbk(s: &str) -> BoundedVec<u8, KeyLimit> {
 /// Turns a string into a BoundedVec
 fn stbd(s: &str) -> StringLimitOf<Test> {
 	s.as_bytes().to_vec().try_into().unwrap()
-}
-
-/// Turns a string into a Vec
-fn stv(s: &str) -> Vec<u8> {
-	s.as_bytes().to_vec()
 }
 
 macro_rules! bvec {

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -15,7 +15,8 @@ use sp_runtime::traits::StaticLookup;
 pub use pallet::*;
 
 use rmrk_traits::{
-	primitives::*, AccountIdOrCollectionNftTuple, Base, BaseInfo, EquippableList, PartType, Theme,
+	primitives::*, AccountIdOrCollectionNftTuple, Base, BaseInfo,
+	EquippableList, PartType, Theme,
 	ThemeProperty,
 };
 

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -15,8 +15,8 @@ use sp_runtime::traits::StaticLookup;
 pub use pallet::*;
 
 use rmrk_traits::{
-	primitives::*, AccountIdOrCollectionNftTuple, Base, BaseInfo, BasicResource,
-	ComposableResource, EquippableList, PartType, ResourceTypes, SlotResource, Theme, ThemeProperty,
+	primitives::*, AccountIdOrCollectionNftTuple, Base, BaseInfo,
+	EquippableList, PartType, Theme, ThemeProperty,
 };
 
 use sp_std::vec::Vec;
@@ -426,7 +426,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
-			let part_length: u32 = parts.len().try_into().unwrap();
+			let _part_length: u32 = parts.len().try_into().unwrap();
 			let base_id = Self::base_create(sender.clone(), base_type, symbol, parts)?;
 
 			Self::deposit_event(Event::BaseCreated { issuer: sender, base_id });

--- a/pallets/rmrk-equip/src/lib.rs
+++ b/pallets/rmrk-equip/src/lib.rs
@@ -15,8 +15,8 @@ use sp_runtime::traits::StaticLookup;
 pub use pallet::*;
 
 use rmrk_traits::{
-	primitives::*, AccountIdOrCollectionNftTuple, Base, BaseInfo,
-	EquippableList, PartType, Theme, ThemeProperty,
+	primitives::*, AccountIdOrCollectionNftTuple, Base, BaseInfo, EquippableList, PartType, Theme,
+	ThemeProperty,
 };
 
 use sp_std::vec::Vec;
@@ -43,23 +43,15 @@ pub type BaseInfoOf<T> = BaseInfo<<T as frame_system::Config>::AccountId, String
 
 pub type PartTypeOf<T> = PartType<
 	StringLimitOf<T>,
-	BoundedVec<
-		CollectionId,
-		<T as Config>::MaxCollectionsEquippablePerPart
-	>
+	BoundedVec<CollectionId, <T as Config>::MaxCollectionsEquippablePerPart>,
 >;
 
 pub type ThemePropertyOf<T> = ThemeProperty<StringLimitOf<T>>;
 
-pub type BoundedThemePropertiesOf<T> = BoundedVec<
-	ThemePropertyOf<T>,
-	<T as Config>::MaxPropertiesPerTheme,
->;
+pub type BoundedThemePropertiesOf<T> =
+	BoundedVec<ThemePropertyOf<T>, <T as Config>::MaxPropertiesPerTheme>;
 
-pub type BoundedThemeOf<T> = Theme<
-	StringLimitOf<T>,
-	BoundedThemePropertiesOf<T>,
->;
+pub type BoundedThemeOf<T> = Theme<StringLimitOf<T>, BoundedThemePropertiesOf<T>>;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -85,15 +77,8 @@ pub mod pallet {
 	/// Stores Bases info (issuer, base_type, symbol, parts)
 	/// TODO https://github.com/rmrk-team/rmrk-substrate/issues/98
 	/// Delete Parts from Bases info, as it's kept in Parts storage
-	pub type Bases<T: Config> = StorageMap<
-		_,
-		Twox64Concat,
-		BaseId,
-		BaseInfo<
-			T::AccountId,
-			StringLimitOf<T>,
-		>,
-	>;
+	pub type Bases<T: Config> =
+		StorageMap<_, Twox64Concat, BaseId, BaseInfo<T::AccountId, StringLimitOf<T>>>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn parts)]

--- a/pallets/rmrk-equip/src/tests.rs
+++ b/pallets/rmrk-equip/src/tests.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-use rmrk_traits::{FixedPart, SlotPart, ThemeProperty};
+use rmrk_traits::{FixedPart, SlotPart, ThemeProperty, ComposableResource, SlotResource};
 
 use frame_support::{assert_noop, assert_ok};
 use mock::{Event as MockEvent, *};
@@ -106,7 +106,7 @@ fn change_base_issuer_works() {
 #[should_panic]
 fn exceeding_parts_bound_panics() {
 	// PartsLimit bound is 50 per mock.rs, 60 should panic on unwrap
-	let parts_bounded_vec: BoundedVec<PartId, PartsLimit> = bvec![
+	let _parts_bounded_vec: BoundedVec<PartId, PartsLimit> = bvec![
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9,
 		10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8,
 		9, 10,
@@ -976,7 +976,7 @@ fn theme_add_too_many_properties_fails() {
 
 		// We only run this to avoid having to define default_theme's type above
 		// Otherwise it will fail to compile
-		RmrkEquip::theme_add(
+		let _add_theme_result = RmrkEquip::theme_add(
 			Origin::signed(ALICE),
 			0, // BaseID
 			default_theme,

--- a/pallets/rmrk-market/src/mock.rs
+++ b/pallets/rmrk-market/src/mock.rs
@@ -164,7 +164,6 @@ pub const CHARLIE: AccountId = AccountId::new([3u8; 32]);
 pub const UNITS: Balance = 100_000_000_000;
 pub const RMRK: Balance = 1;
 pub const COLLECTION_ID_0: <Test as pallet_uniques::Config>::CollectionId = 0;
-pub const COLLECTION_ID_1: <Test as pallet_uniques::Config>::CollectionId = 1;
 pub const NFT_ID_0: <Test as pallet_uniques::Config>::ItemId = 0;
 pub const NFT_ID_1: <Test as pallet_uniques::Config>::ItemId = 1;
 pub const NOT_EXISTING_NFT_ID: <Test as pallet_uniques::Config>::ItemId = 999;

--- a/pallets/rmrk-market/src/tests.rs
+++ b/pallets/rmrk-market/src/tests.rs
@@ -5,25 +5,10 @@
 use super::*;
 use crate::mock::*;
 use frame_support::{assert_noop, assert_ok};
-use mock::{Event as MockEvent, *};
+use mock::{Event as MockEvent};
 
 use sp_runtime::Permill;
-use sp_std::{convert::TryInto, vec::Vec};
-
-/// Turns a string into a BoundedVec
-fn stb(s: &str) -> BoundedVec<u8, ValueLimit> {
-	s.as_bytes().to_vec().try_into().unwrap()
-}
-
-/// Turns a string into a BoundedVec
-fn stbk(s: &str) -> BoundedVec<u8, KeyLimit> {
-	s.as_bytes().to_vec().try_into().unwrap()
-}
-
-/// Turns a string into a Vec
-fn stv(s: &str) -> Vec<u8> {
-	s.as_bytes().to_vec()
-}
+use sp_std::convert::TryInto;
 
 macro_rules! bvec {
 	($( $x:tt )*) => {

--- a/traits/src/base.rs
+++ b/traits/src/base.rs
@@ -2,10 +2,7 @@
 // This file is part of rmrk-substrate.
 // License: Apache 2.0 modified by RMRK, see LICENSE.md
 
-use super::{
-	part::EquippableList,
-	theme::Theme,
-};
+use super::{part::EquippableList, theme::Theme};
 use crate::{
 	primitives::{BaseId, ResourceId, SlotId},
 	serialize,
@@ -13,7 +10,7 @@ use crate::{
 use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
-use sp_runtime::{DispatchError};
+use sp_runtime::DispatchError;
 
 #[cfg(feature = "std")]
 use serde::Serialize;
@@ -22,12 +19,10 @@ use serde::Serialize;
 #[derive(Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(
 	feature = "std",
-	serde(
-		bound = r#"
+	serde(bound = r#"
 			AccountId: Serialize,
 			BoundedString: AsRef<[u8]>
-		"#
-	)
+		"#)
 )]
 pub struct BaseInfo<AccountId, BoundedString> {
 	/// Original creator of the Base

--- a/traits/src/base.rs
+++ b/traits/src/base.rs
@@ -3,18 +3,17 @@
 // License: Apache 2.0 modified by RMRK, see LICENSE.md
 
 use super::{
-	part::{EquippableList, PartType},
+	part::EquippableList,
 	theme::Theme,
 };
 use crate::{
 	primitives::{BaseId, ResourceId, SlotId},
-	serialize, ThemeProperty,
+	serialize,
 };
 use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
-use sp_runtime::{DispatchError, RuntimeDebug};
-use sp_std::vec::Vec;
+use sp_runtime::{DispatchError};
 
 #[cfg(feature = "std")]
 use serde::Serialize;

--- a/traits/src/collection.rs
+++ b/traits/src/collection.rs
@@ -18,13 +18,11 @@ use sp_std::result::Result;
 #[derive(Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(
 	feature = "std",
-	serde(
-		bound = r#"
+	serde(bound = r#"
 			AccountId: Serialize,
 			BoundedString: AsRef<[u8]>,
 			BoundedSymbol: AsRef<[u8]>
-		"#
-	)
+		"#)
 )]
 pub struct CollectionInfo<BoundedString, BoundedSymbol, AccountId> {
 	/// Current bidder and bid price.

--- a/traits/src/collection.rs
+++ b/traits/src/collection.rs
@@ -5,7 +5,7 @@
 use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
-use sp_runtime::{DispatchError, DispatchResult, RuntimeDebug};
+use sp_runtime::{DispatchError, DispatchResult};
 
 #[cfg(feature = "std")]
 use serde::Serialize;

--- a/traits/src/part.rs
+++ b/traits/src/part.rs
@@ -2,10 +2,7 @@
 // This file is part of rmrk-substrate.
 // License: Apache 2.0 modified by RMRK, see LICENSE.md
 
-use crate::{
-	primitives::*,
-	serialize,
-};
+use crate::{primitives::*, serialize};
 use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
@@ -16,10 +13,7 @@ use serde::Serialize;
 // #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
 #[cfg_attr(feature = "std", derive(Serialize))]
 #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
-#[cfg_attr(
-	feature = "std",
-	serde(bound = "BoundedString: AsRef<[u8]>")
-)]
+#[cfg_attr(feature = "std", serde(bound = "BoundedString: AsRef<[u8]>"))]
 pub struct FixedPart<BoundedString> {
 	pub id: PartId,
 	pub z: ZIndex,
@@ -30,17 +24,11 @@ pub struct FixedPart<BoundedString> {
 
 #[cfg_attr(feature = "std", derive(Serialize))]
 #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
-#[cfg_attr(
-	feature = "std",
-	serde(bound = "BoundedCollectionList: AsRef<[CollectionId]>")
-)]
+#[cfg_attr(feature = "std", serde(bound = "BoundedCollectionList: AsRef<[CollectionId]>"))]
 pub enum EquippableList<BoundedCollectionList> {
 	All,
 	Empty,
-	Custom(
-		#[cfg_attr(feature = "std", serde(with = "serialize::vec"))]
-		BoundedCollectionList
-	),
+	Custom(#[cfg_attr(feature = "std", serde(with = "serialize::vec"))] BoundedCollectionList),
 }
 
 // #[cfg_attr(feature = "std", derive(PartialEq, Eq))]
@@ -48,12 +36,10 @@ pub enum EquippableList<BoundedCollectionList> {
 #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
 #[cfg_attr(
 	feature = "std",
-	serde(
-		bound = r#"
+	serde(bound = r#"
 			BoundedString: AsRef<[u8]>,
 			BoundedCollectionList: AsRef<[CollectionId]>
-		"#
-	)
+		"#)
 )]
 pub struct SlotPart<BoundedString, BoundedCollectionList> {
 	pub id: PartId,
@@ -68,12 +54,10 @@ pub struct SlotPart<BoundedString, BoundedCollectionList> {
 #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq, Eq, MaxEncodedLen)]
 #[cfg_attr(
 	feature = "std",
-	serde(
-		bound = r#"
+	serde(bound = r#"
 			BoundedString: AsRef<[u8]>,
 			BoundedCollectionList: AsRef<[CollectionId]>
-		"#
-	)
+		"#)
 )]
 pub enum PartType<BoundedString, BoundedCollectionList> {
 	FixedPart(FixedPart<BoundedString>),

--- a/traits/src/part.rs
+++ b/traits/src/part.rs
@@ -9,8 +9,6 @@ use crate::{
 use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
-use sp_runtime::RuntimeDebug;
-use sp_std::vec::Vec;
 
 #[cfg(feature = "std")]
 use serde::Serialize;

--- a/traits/src/phantom_type.rs
+++ b/traits/src/phantom_type.rs
@@ -9,9 +9,8 @@ impl<T: TypeInfo + 'static> TypeInfo for PhantomType<T> {
 
 	fn type_info() -> scale_info::Type {
 		use scale_info::{
-			Type, Path,
 			build::{FieldsBuilder, UnnamedFields},
-			type_params,
+			type_params, Path, Type,
 		};
 		Type::builder()
 			.path(Path::new("phantom_type", "PhantomType"))

--- a/traits/src/priority.rs
+++ b/traits/src/priority.rs
@@ -5,7 +5,6 @@
 use sp_runtime::DispatchResult;
 
 use crate::primitives::*;
-use sp_std::vec::Vec;
 
 /// Abstraction over a Priority system.
 #[allow(clippy::upper_case_acronyms)]

--- a/traits/src/resource.rs
+++ b/traits/src/resource.rs
@@ -7,9 +7,9 @@
 use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
 use scale_info::TypeInfo;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use sp_runtime::{DispatchError, DispatchResult, RuntimeDebug};
-use sp_std::{cmp::Eq, result::Result, vec::Vec};
+use sp_std::{cmp::Eq, result::Result};
 
 use crate::{primitives::*, serialize};
 

--- a/traits/src/serialize.rs
+++ b/traits/src/serialize.rs
@@ -2,30 +2,30 @@ use core::convert::AsRef;
 use serde::ser::{self, Serialize};
 
 pub mod vec {
-    use super::*;
+	use super::*;
 
-    pub fn serialize<D, V, C>(value: &C, serializer: D) -> Result<D::Ok, D::Error>
-    where
-        D: ser::Serializer,
-        V: Serialize,
-        C: AsRef<[V]>,
-    {
-        value.as_ref().serialize(serializer)
-    }
+	pub fn serialize<D, V, C>(value: &C, serializer: D) -> Result<D::Ok, D::Error>
+	where
+		D: ser::Serializer,
+		V: Serialize,
+		C: AsRef<[V]>,
+	{
+		value.as_ref().serialize(serializer)
+	}
 }
 
 pub mod opt_vec {
-    use super::*;
+	use super::*;
 
-    pub fn serialize<D, V, C>(value: &Option<C>, serializer: D) -> Result<D::Ok, D::Error>
-    where
-        D: ser::Serializer,
-        V: Serialize,
-        C: AsRef<[V]>,
-    {
-        match value {
-            Some(value) => super::vec::serialize(value, serializer),
-            None => serializer.serialize_none()
-        }
-    }
+	pub fn serialize<D, V, C>(value: &Option<C>, serializer: D) -> Result<D::Ok, D::Error>
+	where
+		D: ser::Serializer,
+		V: Serialize,
+		C: AsRef<[V]>,
+	{
+		match value {
+			Some(value) => super::vec::serialize(value, serializer),
+			None => serializer.serialize_none(),
+		}
+	}
 }

--- a/traits/src/theme.rs
+++ b/traits/src/theme.rs
@@ -4,7 +4,6 @@
 
 use codec::{Decode, Encode};
 use scale_info::TypeInfo;
-use sp_runtime::RuntimeDebug;
 
 #[cfg(feature = "std")]
 use serde::Serialize;

--- a/traits/src/theme.rs
+++ b/traits/src/theme.rs
@@ -14,12 +14,10 @@ use crate::serialize;
 #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq)]
 #[cfg_attr(
 	feature = "std",
-	serde(
-		bound = r#"
+	serde(bound = r#"
 			BoundedString: AsRef<[u8]>,
 			BoundedThemeProperties: AsRef<[ThemeProperty<BoundedString>]>,
-		"#
-	)
+		"#)
 )]
 pub struct Theme<BoundedString, BoundedThemeProperties> {
 	/// Name of the theme
@@ -36,10 +34,7 @@ pub struct Theme<BoundedString, BoundedThemeProperties> {
 
 #[cfg_attr(feature = "std", derive(Eq, Serialize))]
 #[derive(Encode, Decode, Debug, TypeInfo, Clone, PartialEq)]
-#[cfg_attr(
-	feature = "std",
-	serde(bound = "BoundedString: AsRef<[u8]>")
-)]
+#[cfg_attr(feature = "std", serde(bound = "BoundedString: AsRef<[u8]>"))]
 pub struct ThemeProperty<BoundedString> {
 	/// Key of the property
 	#[cfg_attr(feature = "std", serde(with = "serialize::vec"))]


### PR DESCRIPTION
All changes are cosmetic except replacing deprecated `remove_prefix` with `clear_prefix`. See [docs here](https://paritytech.github.io/substrate/master/frame_support/storage/trait.StorageNMap.html)

- [x] all unit test are checked