### PR TITLE
Bug Fix 227 Update Children storage when sending NFT directly to NFT

### DIFF
--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -717,6 +717,13 @@ where
 			Ok(())
 		})?;
 
+		pallet_uniques::Pallet::<T>::do_transfer(
+			collection_id,
+			nft_id,
+			new_owner_account.clone(),
+			|_class_details, _details| Ok(()),
+		)?;
+
 		Self::deposit_event(Event::NFTAccepted {
 			sender,
 			recipient: new_owner,

--- a/pallets/rmrk-core/src/functions.rs
+++ b/pallets/rmrk-core/src/functions.rs
@@ -475,6 +475,9 @@ where
 			transferable,
 		};
 
+		// For Uniques, we need to decode the "virtual account" ID to be the owner
+		let uniques_owner = Self::nft_to_account_id(owner.0, owner.1);
+
 		Nfts::<T>::insert(collection_id, nft_id, nft);
 
 		// increment nfts counter
@@ -485,8 +488,7 @@ where
 			Ok(())
 		})?;
 
-		// For Uniques, we need to decode the "virtual account" ID to be the owner
-		let uniques_owner = Self::nft_to_account_id(owner.0, owner.1);
+		Pallet::<T>::add_child((owner.0, owner.1), (collection_id, nft_id));
 
 		pallet_uniques::Pallet::<T>::do_mint(collection_id, nft_id, uniques_owner, |_details| {
 			Ok(())
@@ -714,13 +716,6 @@ where
 			}
 			Ok(())
 		})?;
-
-		pallet_uniques::Pallet::<T>::do_transfer(
-			collection_id,
-			nft_id,
-			new_owner_account.clone(),
-			|_class_details, _details| Ok(()),
-		)?;
 
 		Self::deposit_event(Event::NFTAccepted {
 			sender,

--- a/pallets/rmrk-core/src/tests.rs
+++ b/pallets/rmrk-core/src/tests.rs
@@ -349,6 +349,20 @@ fn mint_directly_to_nft() {
 
 		// Minted NFT (0, 1) is pending
 		assert!(RmrkCore::nfts(0, 1).unwrap().pending);
+
+		// BOB accepts NFT (0, 1)
+		assert_ok!(RMRKCore::accept_nft(
+			Origin::signed(BOB),
+			COLLECTION_ID_0,
+			1,
+			AccountIdOrCollectionNftTuple::CollectionAndNftTuple(0, 0)
+		));
+
+		// Ensure NFT (0, 1) is part of Children for NFT (0, 0)
+		assert_eq!(
+			Children::<Test>::contains_key((COLLECTION_ID_0, NFT_ID_0), (COLLECTION_ID_0, 1)),
+			true
+		);
 	});
 }
 
@@ -1435,7 +1449,7 @@ fn resource_removal_works() {
 		// Create Composable resource
 		let composable_resource = ComposableResource {
 			parts: vec![0, 1].try_into().unwrap(), // BoundedVec of Parts
-			base: base_id,                               // base_id
+			base: base_id,                         // base_id
 			metadata: None,
 			slot: Some((base_id, slot_id)),
 		};
@@ -1450,20 +1464,33 @@ fn resource_removal_works() {
 		));
 
 		// Values should now exist in EquippableBases and EquippableSlots
-		assert!(EquippableBases::<Test>::get((COLLECTION_ID_0,NFT_ID_0, base_id)).is_some());
-		assert!(EquippableSlots::<Test>::get((COLLECTION_ID_0,NFT_ID_0, resource_id, base_id, slot_id)).is_some());
-		
+		assert!(EquippableBases::<Test>::get((COLLECTION_ID_0, NFT_ID_0, base_id)).is_some());
+		assert!(EquippableSlots::<Test>::get((
+			COLLECTION_ID_0,
+			NFT_ID_0,
+			resource_id,
+			base_id,
+			slot_id
+		))
+		.is_some());
+
 		// Remove resource
 		assert_ok!(RMRKCore::remove_resource(
 			Origin::signed(ALICE),
 			COLLECTION_ID_0,
 			NFT_ID_0,
-			resource_id, 
+			resource_id,
 		));
 
-		assert!(EquippableBases::<Test>::get((COLLECTION_ID_0,NFT_ID_0, base_id)).is_none());
-		assert!(EquippableSlots::<Test>::get((COLLECTION_ID_0,NFT_ID_0, resource_id, base_id, slot_id)).is_none());
-
+		assert!(EquippableBases::<Test>::get((COLLECTION_ID_0, NFT_ID_0, base_id)).is_none());
+		assert!(EquippableSlots::<Test>::get((
+			COLLECTION_ID_0,
+			NFT_ID_0,
+			resource_id,
+			base_id,
+			slot_id
+		))
+		.is_none());
 	});
 }
 


### PR DESCRIPTION
Fix bug #227 where minting directly to NFT does not update the `Children` `StorageDoubleMap` which cause the `Children` to be inconsistent.