### PR TITLE
Restrict who can mint nft

### DIFF
--- a/pallets/rmrk-core/src/lib.rs
+++ b/pallets/rmrk-core/src/lib.rs
@@ -113,7 +113,7 @@ impl<CollectionId: From<u32>, ItemId: From<u32>> BenchmarkHelper<CollectionId, I
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+	use frame_support::{dispatch::DispatchResult, pallet_prelude::*, traits::{EnsureOrigin, EnsureOriginWithArg}};
 	use frame_system::pallet_prelude::*;
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
@@ -142,6 +142,9 @@ pub mod pallet {
 		type CollectionSymbolLimit: Get<u32>;
 
 		type MaxResourcesOnMint: Get<u32>;
+
+        /// Who can mint nft
+        type MinterOrigin: EnsureOrigin<Self::Origin, Success = Self::AccountId>;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -490,7 +493,8 @@ pub mod pallet {
 			transferable: bool,
 			resources: Option<BoundedResourceInfoTypeOf<T>>,
 		) -> DispatchResult {
-			let sender = ensure_signed(origin.clone())?;
+			//let sender = ensure_signed(origin.clone())?;
+            let sender = T::MinterOrigin::ensure_origin(origin.clone())?;
 
 			// Collection must exist and sender must be issuer of collection
 			if let Some(collection_issuer) =

--- a/pallets/rmrk-core/src/mock.rs
+++ b/pallets/rmrk-core/src/mock.rs
@@ -7,9 +7,9 @@ use crate as pallet_rmrk_core;
 
 use frame_support::{
 	parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU32, Everything},
+	traits::{AsEnsureOriginWithArg, ConstU32, Everything, EitherOfDiverse, SortedMembers},
 };
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSignedBy, EnsureSigned};
 use sp_core::{crypto::AccountId32, H256};
 use sp_runtime::{
 	testing::Header,
@@ -57,6 +57,17 @@ parameter_types! {
 #[cfg(feature = "runtime-benchmarks")]
 use pallet_rmrk_core::RmrkBenchmark;
 
+
+parameter_types! {
+    pub AllowedMinters: Vec<AccountId> = vec![];
+}
+
+impl SortedMembers<AccountId> for AllowedMinters {
+    fn sorted_members() -> Vec<AccountId> {
+        AllowedMinters::get()
+    }
+}
+
 impl pallet_rmrk_core::Config for Test {
 	// type Currency = Balances;
 	type Event = Event;
@@ -68,6 +79,8 @@ impl pallet_rmrk_core::Config for Test {
 	type MaxResourcesOnMint = MaxResourcesOnMint;
 	type NestingBudget = NestingBudget;
 	type WeightInfo = weights::SubstrateWeight<Test>;
+    type MinterOrigin = EnsureSignedBy<AllowedMinters, Self::AccountId>;
+
 	#[cfg(feature = "runtime-benchmarks")]
 	type Helper = RmrkBenchmark;
 }


### PR DESCRIPTION
Requirement in mind:
- Only predefined set of users should be able to mint nft

This will effect following:
[ ] Minting nft
[ ] Creating collectable