### PR TITLE
Add cfg attribute to runtime-benchmark Helper in pallet_equip

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -407,6 +407,7 @@ impl pallet_rmrk_equip::Config for Runtime {
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
 	type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
 	type WeightInfo = pallet_rmrk_equip::weights::SubstrateWeight<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
 	type Helper = RmrkBenchmark;
 }
 


### PR DESCRIPTION
Add missing cfg attribute to initialize `pallet_rmrk_equip`'s `Helper` type only under `runtime-benchmark` feature