### PR TITLE
Add cfg attribute to runtime-benchmark Helper in pallet_equip

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -407,6 +407,7 @@ impl pallet_rmrk_equip::Config for Runtime {
 	type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
 	type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
 	type WeightInfo = pallet_rmrk_equip::weights::SubstrateWeight<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
 	type Helper = RmrkBenchmark;
 }
 


### PR DESCRIPTION
- Bring `ProducerOrigin` of `pallet_rmrk_core::Config` into use inside `mint_nft`, `mint_nft_directly_to_nft` and `create_collection`.
- Default to `EnsureSigned` to make no logical change into how chain works